### PR TITLE
feat: permission-aware progress report views

### DIFF
--- a/docs/superpowers/plans/2026-04-08-progress-report-permission-views.md
+++ b/docs/superpowers/plans/2026-04-08-progress-report-permission-views.md
@@ -1,0 +1,1604 @@
+# Progress Report Permission-Aware Views Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor the ProgressReport page so that users see different views based on their permissions — personal progress with an interactive goal×date scatter chart, a team overview, or both via a context switcher.
+
+**Architecture:** A `useProgressReportPermissions` hook derives two boolean flags (`canParticipate`, `canOversee`) from the existing permissions store. `Progress.tsx` becomes a thin orchestrator that renders `PersonalProgressView`, `TeamOverviewView`, or `MemberProgressView` based on those flags and a local `viewMode` state. A `ContextSwitcher` component (MUI ToggleButtonGroup + Autocomplete) only renders when the user has both flags. All components live under `src/components/progress/`.
+
+**Tech Stack:** React 19, MUI v7, Recharts v3, Zustand v5, React Router v7, React Hook Form, Zod, AWS Amplify/Cognito, i18next, @testing-library/react
+
+**Spec:** `docs/superpowers/specs/2026-04-08-progress-report-permission-views-design.md`
+
+---
+
+## File Map
+
+**New files:**
+- `src/hooks/useProgressReportPermissions.ts` — derives `canParticipate` + `canOversee` from permission store
+- `src/components/progress/ContextSwitcher.tsx` — MUI ToggleButtonGroup + Autocomplete for view switching
+- `src/components/progress/GoalActivityChart.tsx` — Recharts ScatterChart (goal × date with clickable dots)
+- `src/components/progress/EntryDrawer.tsx` — MUI Drawer showing a single progress entry detail
+- `src/components/progress/PersonalProgressView.tsx` — personal graph + entries list + create button
+- `src/components/progress/TeamOverviewView.tsx` — aggregate team view with member cards
+- `src/components/progress/MemberProgressView.tsx` — read-only personal view for a selected member
+
+**Modified files:**
+- `src/utils/chartUtils.ts` — add `buildGoalActivityScatterData()` for the scatter chart
+- `src/pages/user/Progress.tsx` — refactored to thin orchestrator using the new components
+
+**Test files:**
+- `src/hooks/__tests__/useProgressReportPermissions.test.ts`
+- `src/components/progress/__tests__/ContextSwitcher.test.tsx`
+- `src/components/progress/__tests__/GoalActivityChart.test.tsx`
+- `src/components/progress/__tests__/EntryDrawer.test.tsx`
+- `src/components/progress/__tests__/PersonalProgressView.test.tsx`
+- `src/components/progress/__tests__/TeamOverviewView.test.tsx`
+
+---
+
+## Task 1: Add `buildGoalActivityScatterData` to `chartUtils.ts`
+
+**Files:**
+- Modify: `src/utils/chartUtils.ts`
+- Test: `src/utils/__tests__/chartUtils.test.ts` (create if it doesn't exist)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to (or create) `src/utils/__tests__/chartUtils.test.ts`:
+
+```ts
+import { buildGoalActivityScatterData } from '../chartUtils';
+
+const mockGoals = [
+  { id: 'goal-1', title: 'Serve accuracy' },
+  { id: 'goal-2', title: 'Jump height' },
+];
+
+const mockReports = [
+  {
+    id: 'report-1',
+    authorId: 'user-1',
+    reportDate: '2025-03-01T00:00:00Z',
+    summary: 'Good week',
+    progress: [
+      { id: 'entry-1', goalId: 'goal-1', rating: 4, details: 'Improved' },
+      { id: 'entry-2', goalId: 'goal-2', rating: 2, details: 'Struggling' },
+    ],
+  },
+];
+
+describe('buildGoalActivityScatterData', () => {
+  it('maps each progress entry to a scatter point', () => {
+    const { points, goalNames } = buildGoalActivityScatterData(mockReports as any, mockGoals as any);
+
+    expect(points).toHaveLength(2);
+    expect(goalNames).toEqual(['Serve accuracy', 'Jump height']);
+
+    expect(points[0]).toMatchObject({
+      x: new Date('2025-03-01T00:00:00Z').getTime(),
+      y: 0,
+      rating: 4,
+      progressId: 'entry-1',
+      reportId: 'report-1',
+      goalName: 'Serve accuracy',
+      isOnTrack: true,
+    });
+
+    expect(points[1]).toMatchObject({
+      y: 1,
+      rating: 2,
+      isOnTrack: false,
+    });
+  });
+
+  it('skips progress entries whose goalId is not in the goals list', () => {
+    const reportsWithUnknownGoal = [
+      {
+        id: 'report-2',
+        reportDate: '2025-03-05T00:00:00Z',
+        progress: [{ id: 'e-1', goalId: 'unknown-goal', rating: 3 }],
+      },
+    ];
+    const { points } = buildGoalActivityScatterData(reportsWithUnknownGoal as any, mockGoals as any);
+    expect(points).toHaveLength(0);
+  });
+
+  it('returns empty arrays when there are no reports', () => {
+    const { points, goalNames } = buildGoalActivityScatterData([], mockGoals as any);
+    expect(points).toHaveLength(0);
+    expect(goalNames).toEqual(['Serve accuracy', 'Jump height']);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test -- --testPathPattern="chartUtils"
+```
+
+Expected: FAIL — `buildGoalActivityScatterData is not a function`
+
+- [ ] **Step 3: Add the type and function to `chartUtils.ts`**
+
+Append to `src/utils/chartUtils.ts`:
+
+```ts
+export interface ScatterPoint {
+  x: number;         // report date as Unix timestamp (ms)
+  y: number;         // index into goalNames array
+  rating: number;    // 1–5
+  progressId: string;
+  reportId: string;
+  goalName: string;
+  isOnTrack: boolean; // rating >= 3
+}
+
+export function buildGoalActivityScatterData(
+  reports: Array<{
+    id: string;
+    reportDate: string;
+    progress?: Array<{ id: string; goalId: string; rating: number; details?: string }>;
+  }>,
+  goals: Array<{ id: string; title: string }>,
+): { points: ScatterPoint[]; goalNames: string[] } {
+  const goalIndexMap = new Map(goals.map((g, i) => [g.id, i]));
+  const goalNames = goals.map((g) => g.title);
+  const points: ScatterPoint[] = [];
+
+  for (const report of reports) {
+    const x = new Date(report.reportDate).getTime();
+    for (const entry of report.progress ?? []) {
+      const y = goalIndexMap.get(entry.goalId);
+      if (y === undefined) continue;
+      points.push({
+        x,
+        y,
+        rating: entry.rating,
+        progressId: entry.id,
+        reportId: report.id,
+        goalName: goalNames[y],
+        isOnTrack: entry.rating >= 3,
+      });
+    }
+  }
+
+  return { points, goalNames };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npm test -- --testPathPattern="chartUtils"
+```
+
+Expected: PASS — all 3 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/chartUtils.ts src/utils/__tests__/chartUtils.test.ts
+git commit -m "feat: add buildGoalActivityScatterData to chartUtils"
+```
+
+---
+
+## Task 2: Create `useProgressReportPermissions` Hook
+
+**Files:**
+- Create: `src/hooks/useProgressReportPermissions.ts`
+- Test: `src/hooks/__tests__/useProgressReportPermissions.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/hooks/__tests__/useProgressReportPermissions.test.ts`:
+
+```ts
+import { renderHook } from '@testing-library/react';
+import { useProgressReportPermissions } from '../useProgressReportPermissions';
+import { usePermission } from '../usePermission';
+
+jest.mock('../usePermission');
+const mockUsePermission = usePermission as jest.MockedFunction<typeof usePermission>;
+
+describe('useProgressReportPermissions', () => {
+  it('returns canParticipate=true when individual_goals:write permission exists', () => {
+    mockUsePermission.mockImplementation((p) => p === 'individual_goals:write');
+    const { result } = renderHook(() => useProgressReportPermissions());
+    expect(result.current.canParticipate).toBe(true);
+    expect(result.current.canOversee).toBe(false);
+  });
+
+  it('returns canOversee=true when members:read permission exists', () => {
+    mockUsePermission.mockImplementation((p) => p === 'members:read');
+    const { result } = renderHook(() => useProgressReportPermissions());
+    expect(result.current.canParticipate).toBe(false);
+    expect(result.current.canOversee).toBe(true);
+  });
+
+  it('returns both flags true when user has both permissions', () => {
+    mockUsePermission.mockReturnValue(true);
+    const { result } = renderHook(() => useProgressReportPermissions());
+    expect(result.current.canParticipate).toBe(true);
+    expect(result.current.canOversee).toBe(true);
+  });
+
+  it('returns both flags false when user has neither permission', () => {
+    mockUsePermission.mockReturnValue(false);
+    const { result } = renderHook(() => useProgressReportPermissions());
+    expect(result.current.canParticipate).toBe(false);
+    expect(result.current.canOversee).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test -- --testPathPattern="useProgressReportPermissions"
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create `src/hooks/useProgressReportPermissions.ts`**
+
+```ts
+import { usePermission } from './usePermission';
+
+export interface ProgressReportPermissions {
+  /** User can create/edit their own progress reports */
+  canParticipate: boolean;
+  /** User can view all team members' progress reports */
+  canOversee: boolean;
+}
+
+export function useProgressReportPermissions(): ProgressReportPermissions {
+  const canParticipate = usePermission('individual_goals:write');
+  const canOversee = usePermission('members:read');
+  return { canParticipate, canOversee };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npm test -- --testPathPattern="useProgressReportPermissions"
+```
+
+Expected: PASS — all 4 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useProgressReportPermissions.ts src/hooks/__tests__/useProgressReportPermissions.test.ts
+git commit -m "feat: add useProgressReportPermissions hook"
+```
+
+---
+
+## Task 3: Create `GoalActivityChart` Component
+
+**Files:**
+- Create: `src/components/progress/GoalActivityChart.tsx`
+- Test: `src/components/progress/__tests__/GoalActivityChart.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/progress/__tests__/GoalActivityChart.test.tsx`:
+
+```tsx
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GoalActivityChart } from '../GoalActivityChart';
+
+// Recharts renders SVG — suppress ResizeObserver errors in jsdom
+global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} };
+
+const mockGoalNames = ['Serve accuracy', 'Jump height'];
+const mockPoints = [
+  {
+    x: new Date('2025-03-01').getTime(),
+    y: 0,
+    rating: 4,
+    progressId: 'entry-1',
+    reportId: 'report-1',
+    goalName: 'Serve accuracy',
+    isOnTrack: true,
+  },
+  {
+    x: new Date('2025-03-10').getTime(),
+    y: 1,
+    rating: 2,
+    progressId: 'entry-2',
+    reportId: 'report-2',
+    goalName: 'Jump height',
+    isOnTrack: false,
+  },
+];
+
+describe('GoalActivityChart', () => {
+  it('renders goal names as Y-axis labels', () => {
+    render(
+      <GoalActivityChart
+        points={mockPoints}
+        goalNames={mockGoalNames}
+        onEntryClick={jest.fn()}
+      />,
+    );
+    expect(screen.getByText('Serve accuracy')).toBeInTheDocument();
+    expect(screen.getByText('Jump height')).toBeInTheDocument();
+  });
+
+  it('renders a dot for each scatter point', () => {
+    render(
+      <GoalActivityChart
+        points={mockPoints}
+        goalNames={mockGoalNames}
+        onEntryClick={jest.fn()}
+      />,
+    );
+    // Each dot renders its rating as text
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('calls onEntryClick with progressId and reportId when a dot is clicked', async () => {
+    const onEntryClick = jest.fn();
+    render(
+      <GoalActivityChart
+        points={mockPoints}
+        goalNames={mockGoalNames}
+        onEntryClick={onEntryClick}
+      />,
+    );
+    await userEvent.click(screen.getByText('4'));
+    expect(onEntryClick).toHaveBeenCalledWith('entry-1', 'report-1');
+  });
+
+  it('renders an empty state message when there are no points', () => {
+    render(
+      <GoalActivityChart
+        points={[]}
+        goalNames={mockGoalNames}
+        onEntryClick={jest.fn()}
+      />,
+    );
+    expect(screen.getByText(/no progress entries/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test -- --testPathPattern="GoalActivityChart"
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create `src/components/progress/GoalActivityChart.tsx`**
+
+```tsx
+import React from 'react';
+import {
+  ResponsiveContainer,
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+} from 'recharts';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import { ScatterPoint } from '../../utils/chartUtils';
+
+interface GoalActivityChartProps {
+  points: ScatterPoint[];
+  goalNames: string[];
+  onEntryClick: (progressId: string, reportId: string) => void;
+}
+
+interface DotProps {
+  cx?: number;
+  cy?: number;
+  payload?: ScatterPoint;
+  onEntryClick: (progressId: string, reportId: string) => void;
+}
+
+function ActivityDot({ cx = 0, cy = 0, payload, onEntryClick }: DotProps) {
+  if (!payload) return null;
+  const color = payload.isOnTrack ? '#1976d2' : '#e67e22';
+  return (
+    <g
+      onClick={() => onEntryClick(payload.progressId, payload.reportId)}
+      style={{ cursor: 'pointer' }}
+      role="button"
+      aria-label={`Rating ${payload.rating} for ${payload.goalName}`}
+    >
+      <circle cx={cx} cy={cy} r={14} fill={color} opacity={0.85} />
+      <text
+        x={cx}
+        y={cy}
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fill="white"
+        fontSize={12}
+        fontWeight="bold"
+        pointerEvents="none"
+      >
+        {payload.rating}
+      </text>
+    </g>
+  );
+}
+
+export function GoalActivityChart({ points, goalNames, onEntryClick }: GoalActivityChartProps) {
+  if (points.length === 0) {
+    return (
+      <Box sx={{ py: 4, textAlign: 'center' }}>
+        <Typography color="text.secondary">No progress entries yet this season.</Typography>
+      </Box>
+    );
+  }
+
+  const chartHeight = Math.max(goalNames.length * 64 + 60, 160);
+
+  const formatXTick = (timestamp: number) =>
+    new Date(timestamp).toLocaleDateString('default', { month: 'short', day: 'numeric' });
+
+  const formatYTick = (index: number) => goalNames[index] ?? '';
+
+  return (
+    <ResponsiveContainer width="100%" height={chartHeight}>
+      <ScatterChart margin={{ top: 16, right: 24, bottom: 16, left: 8 }}>
+        <CartesianGrid strokeDasharray="3 3" vertical={false} />
+        <XAxis
+          dataKey="x"
+          type="number"
+          domain={['dataMin - 86400000', 'dataMax + 86400000']}
+          tickFormatter={formatXTick}
+          name="Date"
+          scale="time"
+        />
+        <YAxis
+          dataKey="y"
+          type="number"
+          domain={[-0.5, goalNames.length - 0.5]}
+          ticks={goalNames.map((_, i) => i)}
+          tickFormatter={formatYTick}
+          width={110}
+        />
+        <Tooltip
+          content={({ active, payload }) => {
+            if (!active || !payload?.length) return null;
+            const p = payload[0].payload as ScatterPoint;
+            return (
+              <Box sx={{ bgcolor: 'background.paper', border: 1, borderColor: 'divider', p: 1, borderRadius: 1 }}>
+                <Typography variant="caption" display="block" fontWeight="bold">{p.goalName}</Typography>
+                <Typography variant="caption" display="block">Rating: {p.rating}/5</Typography>
+                <Typography variant="caption" color="text.secondary">Click to open</Typography>
+              </Box>
+            );
+          }}
+        />
+        <Scatter
+          data={points}
+          shape={(props: any) => <ActivityDot {...props} onEntryClick={onEntryClick} />}
+        />
+      </ScatterChart>
+    </ResponsiveContainer>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npm test -- --testPathPattern="GoalActivityChart"
+```
+
+Expected: PASS — all 4 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/progress/GoalActivityChart.tsx src/components/progress/__tests__/GoalActivityChart.test.tsx
+git commit -m "feat: add GoalActivityChart scatter component"
+```
+
+---
+
+## Task 4: Create `EntryDrawer` Component
+
+**Files:**
+- Create: `src/components/progress/EntryDrawer.tsx`
+- Test: `src/components/progress/__tests__/EntryDrawer.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/progress/__tests__/EntryDrawer.test.tsx`:
+
+```tsx
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { EntryDrawer } from '../EntryDrawer';
+import { MemoryRouter } from 'react-router-dom';
+
+const mockEntry = {
+  id: 'entry-1',
+  goalId: 'goal-1',
+  goalName: 'Serve accuracy',
+  rating: 4,
+  details: 'Really focused this week.',
+  reportId: 'report-1',
+  reportDate: '2025-03-01T00:00:00Z',
+};
+
+function renderWithRouter(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe('EntryDrawer', () => {
+  it('renders nothing when entry is null', () => {
+    const { container } = renderWithRouter(
+      <EntryDrawer entry={null} readonly={false} onClose={jest.fn()} />,
+    );
+    // MUI Drawer with no entry should not show content
+    expect(screen.queryByText('Serve accuracy')).not.toBeInTheDocument();
+  });
+
+  it('shows goal name, rating, and details when entry is provided', () => {
+    renderWithRouter(
+      <EntryDrawer entry={mockEntry} readonly={false} onClose={jest.fn()} />,
+    );
+    expect(screen.getByText('Serve accuracy')).toBeInTheDocument();
+    expect(screen.getByText('4 / 5')).toBeInTheDocument();
+    expect(screen.getByText('Really focused this week.')).toBeInTheDocument();
+  });
+
+  it('hides the "Open full report" link in readonly mode — it is still present (read-only just means no edit controls)', () => {
+    renderWithRouter(
+      <EntryDrawer entry={mockEntry} readonly={true} onClose={jest.fn()} />,
+    );
+    expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /open full report/i })).toBeInTheDocument();
+  });
+
+  it('calls onClose when the close button is clicked', async () => {
+    const onClose = jest.fn();
+    renderWithRouter(
+      <EntryDrawer entry={mockEntry} readonly={false} onClose={onClose} />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test -- --testPathPattern="EntryDrawer"
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create `src/components/progress/EntryDrawer.tsx`**
+
+```tsx
+import React from 'react';
+import Drawer from '@mui/material/Drawer';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import Divider from '@mui/material/Divider';
+import Button from '@mui/material/Button';
+import CloseIcon from '@mui/icons-material/Close';
+import { Link } from 'react-router-dom';
+
+export interface EntryDrawerEntry {
+  id: string;
+  goalId: string;
+  goalName: string;
+  rating: number;
+  details?: string;
+  reportId: string;
+  reportDate: string;
+}
+
+interface EntryDrawerProps {
+  entry: EntryDrawerEntry | null;
+  readonly: boolean;
+  onClose: () => void;
+}
+
+export function EntryDrawer({ entry, readonly, onClose }: EntryDrawerProps) {
+  return (
+    <Drawer anchor="right" open={entry !== null} onClose={onClose}>
+      <Box sx={{ width: 360, p: 3, display: 'flex', flexDirection: 'column', height: '100%' }}>
+        {entry && (
+          <>
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+              <Typography variant="h6" noWrap sx={{ flex: 1 }}>
+                {entry.goalName}
+              </Typography>
+              <IconButton aria-label="close" onClick={onClose} size="small">
+                <CloseIcon />
+              </IconButton>
+            </Box>
+
+            <Typography variant="caption" color="text.secondary" gutterBottom>
+              {new Date(entry.reportDate).toLocaleDateString('default', {
+                year: 'numeric', month: 'long', day: 'numeric',
+              })}
+            </Typography>
+
+            <Divider sx={{ my: 2 }} />
+
+            <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+              Rating
+            </Typography>
+            <Typography variant="h4" fontWeight="bold" gutterBottom>
+              {entry.rating} / 5
+            </Typography>
+
+            {entry.details && (
+              <>
+                <Typography variant="subtitle2" color="text.secondary" gutterBottom sx={{ mt: 2 }}>
+                  Notes
+                </Typography>
+                <Typography variant="body2">{entry.details}</Typography>
+              </>
+            )}
+
+            <Box sx={{ mt: 'auto', pt: 3, display: 'flex', flexDirection: 'column', gap: 1 }}>
+              <Button
+                component={Link}
+                to={`/progress/${entry.reportId}`}
+                variant="outlined"
+                fullWidth
+                aria-label="open full report"
+              >
+                Open full report
+              </Button>
+
+              {!readonly && (
+                <Button
+                  component={Link}
+                  to={`/progress/${entry.reportId}`}
+                  variant="contained"
+                  fullWidth
+                >
+                  Edit
+                </Button>
+              )}
+            </Box>
+          </>
+        )}
+      </Box>
+    </Drawer>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npm test -- --testPathPattern="EntryDrawer"
+```
+
+Expected: PASS — all 4 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/progress/EntryDrawer.tsx src/components/progress/__tests__/EntryDrawer.test.tsx
+git commit -m "feat: add EntryDrawer component for progress entry detail"
+```
+
+---
+
+## Task 5: Create `ContextSwitcher` Component
+
+**Files:**
+- Create: `src/components/progress/ContextSwitcher.tsx`
+- Test: `src/components/progress/__tests__/ContextSwitcher.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/progress/__tests__/ContextSwitcher.test.tsx`:
+
+```tsx
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ContextSwitcher } from '../ContextSwitcher';
+
+const mockMembers = [
+  { id: 'user-1', name: 'Anna Müller' },
+  { id: 'user-2', name: 'Bob Klein' },
+];
+
+describe('ContextSwitcher', () => {
+  it('shows all three segments when canParticipate and canOversee are both true', () => {
+    render(
+      <ContextSwitcher
+        canParticipate={true}
+        canOversee={true}
+        value="personal"
+        onChange={jest.fn()}
+        members={mockMembers}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /my progress/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /team overview/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /member/i })).toBeInTheDocument();
+  });
+
+  it('does not render at all when only canParticipate is true', () => {
+    const { container } = render(
+      <ContextSwitcher
+        canParticipate={true}
+        canOversee={false}
+        value="personal"
+        onChange={jest.fn()}
+        members={[]}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('does not render at all when only canOversee is true', () => {
+    const { container } = render(
+      <ContextSwitcher
+        canParticipate={false}
+        canOversee={true}
+        value="team"
+        onChange={jest.fn()}
+        members={mockMembers}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('calls onChange with "personal" when My Progress is clicked', async () => {
+    const onChange = jest.fn();
+    render(
+      <ContextSwitcher
+        canParticipate={true}
+        canOversee={true}
+        value="team"
+        onChange={onChange}
+        members={mockMembers}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /my progress/i }));
+    expect(onChange).toHaveBeenCalledWith('personal');
+  });
+
+  it('shows member autocomplete when Member button is active', async () => {
+    render(
+      <ContextSwitcher
+        canParticipate={true}
+        canOversee={true}
+        value="member"
+        onChange={jest.fn()}
+        members={mockMembers}
+      />,
+    );
+    expect(screen.getByPlaceholderText(/search member/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test -- --testPathPattern="ContextSwitcher"
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create `src/components/progress/ContextSwitcher.tsx`**
+
+```tsx
+import React from 'react';
+import Box from '@mui/material/Box';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import Autocomplete from '@mui/material/Autocomplete';
+import TextField from '@mui/material/TextField';
+import PersonIcon from '@mui/icons-material/Person';
+import GroupIcon from '@mui/icons-material/Group';
+
+interface Member {
+  id: string;
+  name: string;
+}
+
+interface ContextSwitcherProps {
+  canParticipate: boolean;
+  canOversee: boolean;
+  /** 'personal' | 'team' | '<memberId>' */
+  value: string;
+  onChange: (value: string) => void;
+  members: Member[];
+}
+
+export function ContextSwitcher({
+  canParticipate,
+  canOversee,
+  value,
+  onChange,
+  members,
+}: ContextSwitcherProps) {
+  // Only render when user has both flags — otherwise the correct view loads directly
+  if (!canParticipate || !canOversee) return null;
+
+  const mainValue = value === 'personal' || value === 'team' ? value : 'member';
+
+  const handleToggle = (_: React.MouseEvent<HTMLElement>, next: string | null) => {
+    if (!next) return; // prevent deselect
+    if (next === 'personal') onChange('personal');
+    if (next === 'team') onChange('team');
+    if (next === 'member') onChange('member'); // cleared until autocomplete picks a member
+  };
+
+  const selectedMember = members.find((m) => m.id === value) ?? null;
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap', mb: 2 }}>
+      <ToggleButtonGroup
+        value={mainValue}
+        exclusive
+        onChange={handleToggle}
+        size="small"
+        aria-label="progress view"
+      >
+        <ToggleButton value="personal" aria-label="my progress">
+          <PersonIcon fontSize="small" sx={{ mr: 0.5 }} />
+          My Progress
+        </ToggleButton>
+        <ToggleButton value="team" aria-label="team overview">
+          <GroupIcon fontSize="small" sx={{ mr: 0.5 }} />
+          Team Overview
+        </ToggleButton>
+        <ToggleButton value="member" aria-label="member">
+          <PersonIcon fontSize="small" sx={{ mr: 0.5 }} />
+          Member ▾
+        </ToggleButton>
+      </ToggleButtonGroup>
+
+      {mainValue === 'member' && (
+        <Autocomplete
+          options={members}
+          getOptionLabel={(m) => m.name}
+          value={selectedMember}
+          onChange={(_, member) => member && onChange(member.id)}
+          sx={{ width: 200 }}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              size="small"
+              placeholder="Search member..."
+              inputProps={{ ...params.inputProps, 'aria-label': 'search member' }}
+            />
+          )}
+          isOptionEqualToValue={(option, val) => option.id === val.id}
+        />
+      )}
+    </Box>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npm test -- --testPathPattern="ContextSwitcher"
+```
+
+Expected: PASS — all 5 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/progress/ContextSwitcher.tsx src/components/progress/__tests__/ContextSwitcher.test.tsx
+git commit -m "feat: add ContextSwitcher component for progress view navigation"
+```
+
+---
+
+## Task 6: Create `PersonalProgressView` Component
+
+**Files:**
+- Create: `src/components/progress/PersonalProgressView.tsx`
+- Test: `src/components/progress/__tests__/PersonalProgressView.test.tsx`
+
+> This component extracts the personal progress content from `src/pages/user/Progress.tsx`. Look at Progress.tsx to see what goals store and report fetching it uses — replicate those patterns here. The existing `buildProgressChartData` (LineChart) is replaced by `GoalActivityChart` (ScatterChart).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/progress/__tests__/PersonalProgressView.test.tsx`:
+
+```tsx
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { PersonalProgressView } from '../PersonalProgressView';
+
+// Stub child components to keep tests focused
+jest.mock('../GoalActivityChart', () => ({
+  GoalActivityChart: () => <div data-testid="goal-activity-chart" />,
+}));
+jest.mock('../EntryDrawer', () => ({
+  EntryDrawer: () => null,
+}));
+jest.mock('../../store/progressReports', () => ({
+  useProgressReportStore: () => ({
+    reportList: { reports: [], count: 0 },
+    fetchReports: jest.fn(),
+  }),
+}));
+jest.mock('../../store/goals', () => ({  // adjust import path to match actual goals store
+  useIndividualGoalStore: () => ({
+    goals: [],
+    fetchGoals: jest.fn(),
+  }),
+}));
+
+describe('PersonalProgressView', () => {
+  it('renders the goal activity chart', () => {
+    render(
+      <MemoryRouter>
+        <PersonalProgressView teamId="team-1" seasonId="season-1" canParticipate={true} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId('goal-activity-chart')).toBeInTheDocument();
+  });
+
+  it('shows the New Report button when canParticipate is true', () => {
+    render(
+      <MemoryRouter>
+        <PersonalProgressView teamId="team-1" seasonId="season-1" canParticipate={true} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole('button', { name: /new report/i })).toBeInTheDocument();
+  });
+
+  it('hides the New Report button when canParticipate is false', () => {
+    render(
+      <MemoryRouter>
+        <PersonalProgressView teamId="team-1" seasonId="season-1" canParticipate={false} />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByRole('button', { name: /new report/i })).not.toBeInTheDocument();
+  });
+});
+```
+
+> **Note:** The mock path `'../../store/goals'` may differ. Check the actual import used in `Progress.tsx` for the goals store and update the mock accordingly.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test -- --testPathPattern="PersonalProgressView"
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create `src/components/progress/PersonalProgressView.tsx`**
+
+```tsx
+import React from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import { useNavigate } from 'react-router-dom';
+import AddIcon from '@mui/icons-material/Add';
+import { GoalActivityChart } from './GoalActivityChart';
+import { EntryDrawer, EntryDrawerEntry } from './EntryDrawer';
+import { buildGoalActivityScatterData } from '../../utils/chartUtils';
+import { useProgressReportStore } from '../../store/progressReports';
+
+// Import goals store using the same import as Progress.tsx — verify the actual path
+// import { useIndividualGoalStore } from '../../store/goals';
+
+interface PersonalProgressViewProps {
+  teamId: string;
+  seasonId: string;
+  canParticipate: boolean;
+  /** When provided, renders this member's data read-only instead of the current user's */
+  authorId?: string;
+}
+
+export function PersonalProgressView({
+  teamId,
+  seasonId,
+  canParticipate,
+  authorId,
+}: PersonalProgressViewProps) {
+  const navigate = useNavigate();
+  const [selectedEntry, setSelectedEntry] = React.useState<EntryDrawerEntry | null>(null);
+
+  const { reportList, fetchReports } = useProgressReportStore();
+  // const { goals, fetchGoals } = useIndividualGoalStore(); // uncomment with actual store
+
+  // Temporary: replace with actual goals store
+  const goals: Array<{ id: string; title: string }> = [];
+
+  React.useEffect(() => {
+    fetchReports(seasonId, authorId ? { authorId } : {});
+    // fetchGoals(teamId);
+  }, [seasonId, teamId, authorId]);
+
+  const { points, goalNames } = buildGoalActivityScatterData(reportList.reports, goals);
+
+  const handleEntryClick = (progressId: string, reportId: string) => {
+    const report = reportList.reports.find((r) => r.id === reportId);
+    if (!report) return;
+    const entry = report.progress?.find((p) => p.id === progressId);
+    if (!entry) return;
+    const goal = goals.find((g) => g.id === entry.goalId);
+    setSelectedEntry({
+      id: entry.id,
+      goalId: entry.goalId,
+      goalName: goal?.title ?? entry.goalId,
+      rating: entry.rating,
+      details: entry.details,
+      reportId: report.id,
+      reportDate: report.reportDate,
+    });
+  };
+
+  const readonly = !!authorId;
+
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
+        <Typography variant="h6">
+          {authorId ? 'Progress' : 'My Progress'}
+        </Typography>
+        {canParticipate && !authorId && (
+          <Button
+            variant="contained"
+            startIcon={<AddIcon />}
+            onClick={() => navigate('/progress/create')}
+          >
+            New Report
+          </Button>
+        )}
+      </Box>
+
+      <GoalActivityChart
+        points={points}
+        goalNames={goalNames}
+        onEntryClick={handleEntryClick}
+      />
+
+      <Box sx={{ mt: 3 }}>
+        <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+          Reports
+        </Typography>
+        {reportList.reports.map((report) => (
+          <Box
+            key={report.id}
+            sx={{
+              p: 1.5,
+              mb: 1,
+              border: 1,
+              borderColor: 'divider',
+              borderRadius: 1,
+              cursor: 'pointer',
+              '&:hover': { bgcolor: 'action.hover' },
+            }}
+            onClick={() => navigate(`/progress/${report.id}`)}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => e.key === 'Enter' && navigate(`/progress/${report.id}`)}
+          >
+            <Typography variant="body2" fontWeight="medium">{report.summary}</Typography>
+            <Typography variant="caption" color="text.secondary">
+              {new Date(report.reportDate).toLocaleDateString()}
+            </Typography>
+          </Box>
+        ))}
+      </Box>
+
+      <EntryDrawer
+        entry={selectedEntry}
+        readonly={readonly}
+        onClose={() => setSelectedEntry(null)}
+      />
+    </Box>
+  );
+}
+```
+
+- [ ] **Step 4: Integrate actual goals store**
+
+Open `src/pages/user/Progress.tsx` and find the goals store import and usage (look for a hook that returns a `goals` array with `id` and `title` fields). Add the same import to `PersonalProgressView.tsx`, uncomment the goals lines, and remove the `const goals = []` placeholder.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+npm test -- --testPathPattern="PersonalProgressView"
+```
+
+Expected: PASS — all 3 tests green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/progress/PersonalProgressView.tsx src/components/progress/__tests__/PersonalProgressView.test.tsx
+git commit -m "feat: add PersonalProgressView with interactive scatter chart"
+```
+
+---
+
+## Task 7: Create `TeamOverviewView` Component
+
+**Files:**
+- Create: `src/components/progress/TeamOverviewView.tsx`
+- Test: `src/components/progress/__tests__/TeamOverviewView.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/progress/__tests__/TeamOverviewView.test.tsx`:
+
+```tsx
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TeamOverviewView } from '../TeamOverviewView';
+
+jest.mock('../../store/progressReports', () => ({
+  useProgressReportStore: () => ({
+    reportList: {
+      reports: [
+        { id: 'r1', authorId: 'user-1', reportDate: '2025-03-01T00:00:00Z', summary: 'S1', progress: [] },
+        { id: 'r2', authorId: 'user-2', reportDate: '2025-03-05T00:00:00Z', summary: 'S2', progress: [] },
+      ],
+    },
+    fetchReports: jest.fn(),
+  }),
+}));
+
+const mockMembers = [
+  { id: 'user-1', name: 'Anna Müller', picture: undefined },
+  { id: 'user-2', name: 'Bob Klein', picture: undefined },
+];
+
+describe('TeamOverviewView', () => {
+  it('renders a card for each team member', () => {
+    render(
+      <TeamOverviewView
+        teamId="team-1"
+        seasonId="season-1"
+        members={mockMembers}
+        onMemberSelect={jest.fn()}
+      />,
+    );
+    expect(screen.getByText('Anna Müller')).toBeInTheDocument();
+    expect(screen.getByText('Bob Klein')).toBeInTheDocument();
+  });
+
+  it('shows the report count per member', () => {
+    render(
+      <TeamOverviewView
+        teamId="team-1"
+        seasonId="season-1"
+        members={mockMembers}
+        onMemberSelect={jest.fn()}
+      />,
+    );
+    // Anna has 1 report, Bob has 1 report
+    expect(screen.getAllByText(/1 report/i)).toHaveLength(2);
+  });
+
+  it('calls onMemberSelect with memberId when a member card is clicked', async () => {
+    const onMemberSelect = jest.fn();
+    render(
+      <TeamOverviewView
+        teamId="team-1"
+        seasonId="season-1"
+        members={mockMembers}
+        onMemberSelect={onMemberSelect}
+      />,
+    );
+    await userEvent.click(screen.getByText('Anna Müller'));
+    expect(onMemberSelect).toHaveBeenCalledWith('user-1');
+  });
+
+  it('filters members when search input is used', async () => {
+    render(
+      <TeamOverviewView
+        teamId="team-1"
+        seasonId="season-1"
+        members={mockMembers}
+        onMemberSelect={jest.fn()}
+      />,
+    );
+    await userEvent.type(screen.getByPlaceholderText(/search/i), 'Anna');
+    expect(screen.getByText('Anna Müller')).toBeInTheDocument();
+    expect(screen.queryByText('Bob Klein')).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test -- --testPathPattern="TeamOverviewView"
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create `src/components/progress/TeamOverviewView.tsx`**
+
+```tsx
+import React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import Grid from '@mui/material/Grid';
+import Card from '@mui/material/Card';
+import CardActionArea from '@mui/material/CardActionArea';
+import CardContent from '@mui/material/CardContent';
+import Avatar from '@mui/material/Avatar';
+import LinearProgress from '@mui/material/LinearProgress';
+import InputAdornment from '@mui/material/InputAdornment';
+import SearchIcon from '@mui/icons-material/Search';
+import { useProgressReportStore } from '../../store/progressReports';
+
+interface Member {
+  id: string;
+  name: string;
+  picture?: string;
+}
+
+interface TeamOverviewViewProps {
+  teamId: string;
+  seasonId: string;
+  members: Member[];
+  onMemberSelect: (memberId: string) => void;
+}
+
+export function TeamOverviewView({
+  teamId,
+  seasonId,
+  members,
+  onMemberSelect,
+}: TeamOverviewViewProps) {
+  const [search, setSearch] = React.useState('');
+  const { reportList, fetchReports } = useProgressReportStore();
+
+  React.useEffect(() => {
+    fetchReports(seasonId, {});
+  }, [seasonId]);
+
+  const reportCountByAuthor = React.useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const report of reportList.reports) {
+      counts[report.authorId] = (counts[report.authorId] ?? 0) + 1;
+    }
+    return counts;
+  }, [reportList.reports]);
+
+  const maxReports = Math.max(...Object.values(reportCountByAuthor), 1);
+
+  const filteredMembers = members.filter((m) =>
+    m.name.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
+        <Typography variant="h6">Team Overview</Typography>
+        <TextField
+          size="small"
+          placeholder="Search members..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon fontSize="small" />
+              </InputAdornment>
+            ),
+          }}
+          sx={{ width: 200 }}
+        />
+      </Box>
+
+      <Grid container spacing={2}>
+        {filteredMembers.map((member) => {
+          const count = reportCountByAuthor[member.id] ?? 0;
+          const progress = (count / maxReports) * 100;
+          return (
+            <Grid item xs={12} sm={6} md={4} key={member.id}>
+              <Card variant="outlined">
+                <CardActionArea onClick={() => onMemberSelect(member.id)}>
+                  <CardContent>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1.5 }}>
+                      <Avatar src={member.picture} sx={{ width: 36, height: 36 }}>
+                        {member.name[0]}
+                      </Avatar>
+                      <Typography variant="subtitle2" fontWeight="bold">
+                        {member.name}
+                      </Typography>
+                    </Box>
+                    <Typography variant="caption" color="text.secondary" gutterBottom>
+                      {count} {count === 1 ? 'report' : 'reports'} this season
+                    </Typography>
+                    <LinearProgress
+                      variant="determinate"
+                      value={progress}
+                      sx={{ mt: 1, height: 6, borderRadius: 3 }}
+                    />
+                  </CardContent>
+                </CardActionArea>
+              </Card>
+            </Grid>
+          );
+        })}
+      </Grid>
+    </Box>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npm test -- --testPathPattern="TeamOverviewView"
+```
+
+Expected: PASS — all 4 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/progress/TeamOverviewView.tsx src/components/progress/__tests__/TeamOverviewView.test.tsx
+git commit -m "feat: add TeamOverviewView with member cards and search"
+```
+
+---
+
+## Task 8: Create `MemberProgressView` Component
+
+**Files:**
+- Create: `src/components/progress/MemberProgressView.tsx`
+
+> `MemberProgressView` is a thin wrapper around `PersonalProgressView` with `readonly` semantics. It passes the selected member's `userId` as `authorId` and shows a back button.
+
+- [ ] **Step 1: Create `src/components/progress/MemberProgressView.tsx`**
+
+```tsx
+import React from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import { PersonalProgressView } from './PersonalProgressView';
+
+interface MemberProgressViewProps {
+  memberId: string;
+  memberName: string;
+  teamId: string;
+  seasonId: string;
+  onBack: () => void;
+}
+
+export function MemberProgressView({
+  memberId,
+  memberName,
+  teamId,
+  seasonId,
+  onBack,
+}: MemberProgressViewProps) {
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+        <Button
+          startIcon={<ArrowBackIcon />}
+          onClick={onBack}
+          size="small"
+          variant="text"
+        >
+          Team Overview
+        </Button>
+        <Typography variant="body2" color="text.secondary">
+          / {memberName}
+        </Typography>
+      </Box>
+
+      <Typography variant="caption" color="text.secondary" sx={{ mb: 2, display: 'block' }}>
+        Viewing {memberName}'s progress — read only
+      </Typography>
+
+      <PersonalProgressView
+        teamId={teamId}
+        seasonId={seasonId}
+        canParticipate={false}
+        authorId={memberId}
+      />
+    </Box>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/progress/MemberProgressView.tsx
+git commit -m "feat: add MemberProgressView read-only wrapper"
+```
+
+---
+
+## Task 9: Refactor `Progress.tsx` as Orchestrator
+
+**Files:**
+- Modify: `src/pages/user/Progress.tsx`
+
+> Replace the body of `Progress.tsx` with the orchestration logic. The existing content (chart, list, member fetching) has moved into `PersonalProgressView`. Preserve all existing imports that are still needed (routing params, team/season store access).
+
+- [ ] **Step 1: Read the current `Progress.tsx`**
+
+Open `src/pages/user/Progress.tsx` and note:
+1. How `teamId` and `seasonId` are obtained (params? store?)
+2. How `currentUserId` is obtained (Cognito store?)
+3. Imports that are still needed vs ones now handled by sub-components
+
+- [ ] **Step 2: Replace `Progress.tsx` body**
+
+Keep the file's existing imports for team/season context. Replace the component body with:
+
+```tsx
+import React from 'react';
+import Box from '@mui/material/Box';
+import Container from '@mui/material/Container';
+import { useProgressReportPermissions } from '../../hooks/useProgressReportPermissions';
+import { ContextSwitcher } from '../../components/progress/ContextSwitcher';
+import { PersonalProgressView } from '../../components/progress/PersonalProgressView';
+import { TeamOverviewView } from '../../components/progress/TeamOverviewView';
+import { MemberProgressView } from '../../components/progress/MemberProgressView';
+import { useTeamStore } from '../../store/teams';
+// Keep existing imports for teamId, seasonId, currentUserId resolution
+
+export function Progress() {
+  // Resolve teamId, seasonId from existing store/params — keep as-is from original file
+  const teamId = ''; // replace with existing resolution
+  const seasonId = ''; // replace with existing resolution
+
+  const { canParticipate, canOversee } = useProgressReportPermissions();
+
+  const members = useTeamStore((s) => s.teamMembers) ?? [];
+  const fetchTeamMembers = useTeamStore((s) => s.fetchTeamMembers);
+
+  // 'personal' | 'team' | '<memberId>'
+  const [viewMode, setViewMode] = React.useState<string>(() =>
+    canParticipate ? 'personal' : 'team',
+  );
+
+  React.useEffect(() => {
+    if (canOversee && teamId) {
+      fetchTeamMembers(teamId, { limit: 100 } as any).catch(() => {});
+    }
+  }, [canOversee, teamId]);
+
+  const selectedMember = members.find((m) => m.id === viewMode);
+
+  const isPersonal = viewMode === 'personal';
+  const isTeam = viewMode === 'team';
+  const isMember = !isPersonal && !isTeam;
+
+  // For oversight-only users landing directly on team, ensure viewMode is 'team'
+  React.useEffect(() => {
+    if (!canParticipate && canOversee && viewMode === 'personal') {
+      setViewMode('team');
+    }
+  }, [canParticipate, canOversee]);
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 3 }}>
+      <ContextSwitcher
+        canParticipate={canParticipate}
+        canOversee={canOversee}
+        value={viewMode}
+        onChange={setViewMode}
+        members={members.map((m) => ({ id: m.id, name: m.name }))}
+      />
+
+      <Box>
+        {isPersonal && (
+          <PersonalProgressView
+            teamId={teamId}
+            seasonId={seasonId}
+            canParticipate={canParticipate}
+          />
+        )}
+
+        {isTeam && (
+          <TeamOverviewView
+            teamId={teamId}
+            seasonId={seasonId}
+            members={members.map((m) => ({ id: m.id, name: m.name, picture: m.picture }))}
+            onMemberSelect={(memberId) => setViewMode(memberId)}
+          />
+        )}
+
+        {isMember && selectedMember && (
+          <MemberProgressView
+            memberId={selectedMember.id}
+            memberName={selectedMember.name}
+            teamId={teamId}
+            seasonId={seasonId}
+            onBack={() => setViewMode('team')}
+          />
+        )}
+      </Box>
+    </Container>
+  );
+}
+
+export default Progress;
+```
+
+- [ ] **Step 3: Fill in `teamId` and `seasonId`**
+
+From the original `Progress.tsx`, copy the logic that resolves `teamId` and `seasonId` (likely from a team store or URL params). Replace the empty string placeholders above.
+
+- [ ] **Step 4: Verify the app compiles**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds with no TypeScript errors. Fix any type errors before continuing.
+
+- [ ] **Step 5: Manual smoke test**
+
+Start the dev server:
+```bash
+npm start
+```
+
+Verify:
+1. Log in as a **member** account → `/progress` shows personal graph only, no switcher
+2. Log in as a **trainer** account → `/progress` shows Team Overview directly, member cards clickable
+3. Log in as an **admin (playing)** account → `/progress` shows switcher with all 3 segments, defaults to "My Progress"
+4. Click a dot on any graph → Drawer opens with entry detail
+5. Click a report row → navigates to `/progress/:id`
+6. Click "Open full report" in Drawer → navigates to `/progress/:id`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pages/user/Progress.tsx
+git commit -m "feat: refactor Progress page as permission-aware orchestrator"
+```
+
+---
+
+## Self-Review Checklist
+
+- [x] **Permission detection** — `useProgressReportPermissions` hook in Task 2 ✓
+- [x] **Personal scatter chart** — `GoalActivityChart` with clickable dots in Task 3 ✓
+- [x] **Dot click → Drawer** — `EntryDrawer` in Task 4, wired in `PersonalProgressView` Task 6 ✓
+- [x] **Report row → Navigate** — handled in `PersonalProgressView` Task 6 ✓
+- [x] **Context Switcher (both flags)** — `ContextSwitcher` in Task 5, only renders when both true ✓
+- [x] **Team Overview** — `TeamOverviewView` with member cards in Task 7 ✓
+- [x] **Member drill-down from Team Overview** — `onMemberSelect` prop → `setViewMode(memberId)` in Task 9 ✓
+- [x] **Member drill-down from Switcher** — ToggleButton "Member ▾" + Autocomplete in Task 5 ✓
+- [x] **MemberProgressView always read-only** — `canParticipate={false}`, `authorId` passed in Task 8 ✓
+- [x] **Oversight-only users land on Team view** — `useEffect` correction in Task 9 ✓
+- [x] **Edit/Delete only for own reports** — Drawer shows Edit only when `!readonly` in Task 4; readonly is determined by whether `authorId` is set in Task 8 ✓
+- [x] **No role names read in frontend** — only `canParticipate`/`canOversee` flags used throughout ✓
+- [x] **Scales to 16+ members** — Autocomplete in ContextSwitcher + search in TeamOverviewView ✓

--- a/docs/superpowers/specs/2026-04-08-progress-report-permission-views-design.md
+++ b/docs/superpowers/specs/2026-04-08-progress-report-permission-views-design.md
@@ -1,0 +1,211 @@
+# Progress Report — Permission-Aware Views
+
+**Date:** 2026-04-08
+**Status:** Draft
+**Scope:** Refactor the ProgressReport page to render different views based on the user's permissions, not their role name.
+
+---
+
+## Problem
+
+All users currently see the same ProgressReport view: a personal progress graph and a list of entries. Users with oversight responsibilities (trainers, admins) have no way to see team-level progress or inspect individual members.
+
+---
+
+## Permission Detection
+
+The frontend derives two boolean flags from the current team's permission set. No role name is ever read.
+
+```ts
+const canParticipate = permissions.includes('individual_goals:write')
+const canOversee     = permissions.includes('members:read')
+```
+
+These flags are computed in a `useProgressReportPermissions()` hook and determine the entire view tree.
+
+| `canParticipate` | `canOversee` | View Mode |
+|---|---|---|
+| ✓ | ✗ | Personal only — no switcher |
+| ✗ | ✓ | Team only — lands on Team Overview, no personal section |
+| ✓ | ✓ | Both — Context Switcher visible, defaults to "My Progress" |
+
+---
+
+## UI Design: Context Switcher (Option B)
+
+### Navigation
+
+A 3-segment MUI `ToggleButtonGroup` renders **only when both `canParticipate` and `canOversee` are true**:
+
+```
+[ 👤 My Progress ] [ 👥 Team Overview ] [ 👤 Member ▾ ]
+```
+
+- **My Progress** — switches to personal graph
+- **Team Overview** — switches to team aggregate view
+- **Member ▾** — activates a MUI `Autocomplete` next to the toggle group for selecting any team member (searchable, scales to 16+ members)
+
+When only one flag is true, the toggle group does not render — the correct view loads directly:
+- `canParticipate` only → personal view, no navigation needed
+- `canOversee` only → Team Overview loads directly; member drill-down is accessed by clicking a member card (see Team Overview View)
+
+### Component Tree
+
+```tsx
+<ProgressReportPage>
+  {/* Permission hook */}
+  const { canParticipate, canOversee } = useProgressReportPermissions()
+
+  {/* Switcher — only when user has both */}
+  {canParticipate && canOversee && <ContextSwitcher />}
+
+  {/* View routing */}
+  {view === 'personal' && <PersonalProgressView />}
+  {view === 'team'     && <TeamOverviewView />}
+  {view === memberId   && <MemberProgressView memberId={view} />}
+</ProgressReportPage>
+```
+
+---
+
+## Personal Progress View
+
+### Goal × Date Scatter Chart
+
+The primary visual element is a Recharts `ScatterChart` showing goal activity over time:
+
+- **X axis** — dates (report dates across the current season)
+- **Y axis** — goals (categorical, one row per individual goal)
+- **Dots** — one dot per `Progress` entry (a goal rating within a report)
+  - Number inside dot = rating value (1–5)
+  - Color = performance threshold (blue = on track, orange = needs work)
+- **Interactivity** — clicking a dot opens a MUI Drawer with the entry detail (read/edit depending on ownership)
+
+### Entries List
+
+Below the chart, a scrollable list of `ProgressReport` rows. Clicking a row navigates to the full report detail page.
+
+### Controls
+
+- `+ New Report` button only renders if `canParticipate`
+
+---
+
+## Team Overview View
+
+Rendered when `view === 'team'` (requires `canOversee`):
+
+- Aggregate progress chart across all members
+- Member cards grid: name, report count for the season, progress indicator bar
+- Member search/filter input
+- **Clicking a member card** switches to that member's progress view (replaces the toggle group's "Member ▾" flow for oversight-only users)
+
+No create or edit controls — oversight users cannot create reports on behalf of others.
+
+---
+
+## Member Progress View
+
+Rendered when `view === memberId` (requires `canOversee`):
+
+- Identical layout to PersonalProgressView but for the selected member
+- Always read-only — no `+ New Report`, no Edit/Delete controls regardless of any permission
+- Drawer opens on dot click (read-only entry detail)
+- Report row click navigates to report detail page (read-only)
+
+---
+
+## Interaction Patterns
+
+| Interaction | Result |
+|---|---|
+| Click dot on graph | MUI Drawer — entry detail |
+| Click report row in list | Navigate to `/teams/:id/progress-reports/:reportId` |
+| Edit/Delete on report | Only shown if `report.authorId === currentUserId` |
+| Member autocomplete | MUI Autocomplete, searchable, all team members |
+
+---
+
+## Ownership & Permissions Impact on UI
+
+The backend enforces access via a 5-layer evaluation chain. The frontend reflects this without duplicating logic:
+
+| Situation | UX consequence |
+|---|---|
+| Viewing own report (`authorId === currentUserId`) | Edit + Delete buttons visible |
+| Oversight user viewing another member's report | Read-only — no edit controls rendered |
+| User without `progress_reports:write` | No `+ New Report` button |
+| Oversight user opening entry Drawer for another member | Always read-only mode |
+
+The frontend never hides data based on role name. Controls are shown/hidden based on:
+1. `authorId === currentUserId` — ownership
+2. `canParticipate` / `canOversee` — permission flags
+
+The API is the authoritative enforcer. The UI avoids rendering controls that would result in a 403.
+
+---
+
+## Data Flow
+
+```
+Mount ProgressReportPage
+  └─ useProgressReportPermissions()
+       ├─ canParticipate = permissions.includes('individual_goals:write')
+       └─ canOversee     = permissions.includes('members:read')
+
+  if canOversee     → GET /teams/:id/members
+  if view personal  → GET /teams/:id/progress-reports (own reports)
+  if view team      → GET /teams/:id/progress-reports (all reports)
+  if view memberId  → GET /teams/:id/progress-reports (filtered by authorId)
+```
+
+### Zustand Store Shape
+
+```ts
+{
+  viewMode: 'personal' | 'team' | string,  // string = memberId
+  reports: ProgressReportWithProgress[],
+  members: TeamMember[],
+  selectedEntryId: string | null,          // drives Drawer open/closed
+}
+```
+
+- View switches are instant if data already cached; refetch only on first switch to a new `memberId`
+- `selectedEntryId` drives the Drawer — setting it opens the Drawer, clearing it closes it
+- Scatter chart data is derived from `reports` — no separate fetch
+
+---
+
+## Role Flows (Permission-Derived)
+
+### Member (canParticipate ✓ · canOversee ✗)
+1. Lands on personal graph — no switcher
+2. Reads goal-activity chart; dots show which goals were logged on which dates
+3. Clicks a dot → Drawer opens with entry detail (editable — own report)
+4. Clicks a report row → navigates to full report page (Edit/Delete visible)
+5. Creates new report via `+ New Report`
+
+### Trainer (canParticipate ✗ · canOversee ✓)
+1. Lands on Team Overview directly — no switcher, no personal section
+2. Sees aggregate team chart and member cards
+3. Clicks a member card → switches to that member's goal-activity graph (read-only)
+4. Clicks a dot → read-only Drawer; clicks a row → read-only report detail
+5. Uses browser back / a back button to return to Team Overview
+
+### Admin/playing (canParticipate ✓ · canOversee ✓)
+1. Lands on personal graph (default) — full switcher visible
+2. Uses personal view exactly like a Member (graph, drawer, navigate, create)
+3. Switches to Team Overview — same as Trainer team view
+4. Switches to Member ▾ → inspects any member read-only
+5. Switches back to My Progress — context preserved
+
+---
+
+## Tech Stack Notes
+
+- **Chart:** Recharts `ScatterChart` with categorical Y axis for goals
+- **Navigation:** MUI `ToggleButtonGroup` + MUI `Autocomplete` for member picker
+- **Drawer:** MUI `Drawer` (anchor right) for entry detail
+- **State:** Zustand store; React Router v7 for navigation
+- **Forms:** React Hook Form + Zod for any editable fields in Drawer
+- **Permissions:** Read from existing permissions store — no new API call needed

--- a/src/__tests__/pages/user/Progress.test.tsx
+++ b/src/__tests__/pages/user/Progress.test.tsx
@@ -15,9 +15,15 @@ jest.mock('../../../store/goals', () => { const m: any = jest.fn((s?: any) => s 
 import { useGoalStore } from '../../../store/goals';
 jest.mock('../../../store/teams', () => { const m: any = jest.fn((s?: any) => s ? s({}) : {}); m.getState = () => ({}); return { __esModule: true, useTeamStore: m }; });
 import { useTeamStore } from '../../../store/teams';
+jest.mock('../../../hooks/usePermission', () => ({
+  usePermission: jest.fn((p: string) => p === 'individual_goals:write'),
+}));
+
 jest.mock('recharts', () => ({
   ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
   LineChart: () => <div data-testid="line-chart" />,
+  ScatterChart: ({ children }: any) => <div data-testid="scatter-chart">{children}</div>,
+  Scatter: () => null,
   Line: () => null,
   XAxis: () => null,
   YAxis: () => null,
@@ -55,16 +61,16 @@ describe('Progress', () => {
     expect(screen.getByText('Progress Reports')).toBeInTheDocument();
   });
 
-  it('renders Create Report button', () => {
+  it('renders New Report button when user can participate', () => {
     setup();
     render(<Progress />);
-    expect(screen.getByText('Create Progress Report')).toBeInTheDocument();
+    expect(screen.getByText('New Report')).toBeInTheDocument();
   });
 
-  it('navigates to create page on button click', () => {
+  it('navigates to create page on New Report button click', () => {
     setup();
     render(<Progress />);
-    screen.getByText('Create Progress Report').click();
+    screen.getByText('New Report').click();
     expect(mockNavigate).toHaveBeenCalledWith('/progress/create');
   });
 

--- a/src/components/progress/ContextSwitcher.tsx
+++ b/src/components/progress/ContextSwitcher.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import Autocomplete from '@mui/material/Autocomplete';
+import TextField from '@mui/material/TextField';
+import PersonIcon from '@mui/icons-material/Person';
+import GroupIcon from '@mui/icons-material/Group';
+
+interface Member {
+  id: string;
+  name: string;
+}
+
+interface ContextSwitcherProps {
+  canParticipate: boolean;
+  canOversee: boolean;
+  /** 'personal' | 'team' | '<memberId>' */
+  value: string;
+  onChange: (value: string) => void;
+  members: Member[];
+}
+
+export function ContextSwitcher({
+  canParticipate,
+  canOversee,
+  value,
+  onChange,
+  members,
+}: ContextSwitcherProps) {
+  // Only render when user has both flags — otherwise the correct view loads directly
+  if (!canParticipate || !canOversee) return null;
+
+  const mainValue = value === 'personal' || value === 'team' ? value : 'member';
+
+  const handleToggle = (_: React.MouseEvent<HTMLElement>, next: string | null) => {
+    if (!next) return; // prevent deselect
+    if (next === 'personal') onChange('personal');
+    if (next === 'team') onChange('team');
+    if (next === 'member') onChange('member'); // cleared until autocomplete picks a member
+  };
+
+  const selectedMember = members.find((m) => m.id === value) ?? null;
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap', mb: 2 }}>
+      <ToggleButtonGroup
+        value={mainValue}
+        exclusive
+        onChange={handleToggle}
+        size="small"
+        aria-label="progress view"
+      >
+        <ToggleButton value="personal" aria-label="my progress">
+          <PersonIcon fontSize="small" sx={{ mr: 0.5 }} />
+          My Progress
+        </ToggleButton>
+        <ToggleButton value="team" aria-label="team overview">
+          <GroupIcon fontSize="small" sx={{ mr: 0.5 }} />
+          Team Overview
+        </ToggleButton>
+        <ToggleButton value="member" aria-label="member">
+          <PersonIcon fontSize="small" sx={{ mr: 0.5 }} />
+          Member ▾
+        </ToggleButton>
+      </ToggleButtonGroup>
+
+      {mainValue === 'member' && (
+        <Autocomplete
+          options={members}
+          getOptionLabel={(m) => m.name}
+          value={selectedMember}
+          onChange={(_, member) => member && onChange(member.id)}
+          sx={{ width: 200 }}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              size="small"
+              placeholder="Search member..."
+              inputProps={{ ...params.inputProps, 'aria-label': 'search member' }}
+            />
+          )}
+          isOptionEqualToValue={(option, val) => option.id === val.id}
+        />
+      )}
+    </Box>
+  );
+}

--- a/src/components/progress/EntryDrawer.tsx
+++ b/src/components/progress/EntryDrawer.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import Drawer from '@mui/material/Drawer';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import Divider from '@mui/material/Divider';
+import Button from '@mui/material/Button';
+import CloseIcon from '@mui/icons-material/Close';
+import { Link } from 'react-router-dom';
+
+export interface EntryDrawerEntry {
+  id: string;
+  goalId: string;
+  goalName: string;
+  rating: number;
+  details?: string;
+  reportId: string;
+  reportDate: string;
+}
+
+interface EntryDrawerProps {
+  entry: EntryDrawerEntry | null;
+  readonly: boolean;
+  onClose: () => void;
+}
+
+export function EntryDrawer({ entry, readonly, onClose }: EntryDrawerProps) {
+  return (
+    <Drawer anchor="right" open={entry !== null} onClose={onClose}>
+      <Box sx={{ width: 360, p: 3, display: 'flex', flexDirection: 'column', height: '100%' }}>
+        {entry && (
+          <>
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+              <Typography variant="h6" noWrap sx={{ flex: 1 }}>
+                {entry.goalName}
+              </Typography>
+              <IconButton aria-label="close" onClick={onClose} size="small">
+                <CloseIcon />
+              </IconButton>
+            </Box>
+
+            <Typography variant="caption" color="text.secondary" gutterBottom>
+              {new Date(entry.reportDate).toLocaleDateString('default', {
+                year: 'numeric', month: 'long', day: 'numeric',
+              })}
+            </Typography>
+
+            <Divider sx={{ my: 2 }} />
+
+            <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+              Rating
+            </Typography>
+            <Typography variant="h4" fontWeight="bold" gutterBottom>
+              {entry.rating} / 5
+            </Typography>
+
+            {entry.details && (
+              <>
+                <Typography variant="subtitle2" color="text.secondary" gutterBottom sx={{ mt: 2 }}>
+                  Notes
+                </Typography>
+                <Typography variant="body2">{entry.details}</Typography>
+              </>
+            )}
+
+            <Box sx={{ mt: 'auto', pt: 3, display: 'flex', flexDirection: 'column', gap: 1 }}>
+              <Button
+                component={Link}
+                to={`/progress/${entry.reportId}`}
+                variant="outlined"
+                fullWidth
+                aria-label="open full report"
+              >
+                Open full report
+              </Button>
+
+              {!readonly && (
+                <Button
+                  component={Link}
+                  to={`/progress/${entry.reportId}`}
+                  variant="contained"
+                  fullWidth
+                >
+                  Edit
+                </Button>
+              )}
+            </Box>
+          </>
+        )}
+      </Box>
+    </Drawer>
+  );
+}

--- a/src/components/progress/GoalActivityChart.tsx
+++ b/src/components/progress/GoalActivityChart.tsx
@@ -10,6 +10,8 @@ import {
 } from 'recharts';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
+import { useTheme } from '@mui/material/styles';
+import i18next from 'i18next';
 import { ScatterPoint } from '../../utils/chartUtils';
 
 interface GoalActivityChartProps {
@@ -32,10 +34,18 @@ function ActivityDot({ cx = 0, cy = 0, payload, onEntryClick }: DotProps) {
     : 'var(--palette-warning-main)';
   return (
     <g
+      className="progress-activity-dot"
       onClick={() => onEntryClick(payload.progressId, payload.reportId)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onEntryClick(payload.progressId, payload.reportId);
+        }
+      }}
+      tabIndex={0}
       style={{ cursor: 'pointer' }}
       role="button"
-      aria-label={`Rating ${payload.rating} for ${payload.goalName}`}
+      aria-label={`${i18next.t('progress.graph.rating', 'Rating')} ${payload.rating} — ${payload.goalName}`}
     >
       <circle cx={cx} cy={cy} r={14} fill={color} opacity={0.85} />
       <text
@@ -55,10 +65,14 @@ function ActivityDot({ cx = 0, cy = 0, payload, onEntryClick }: DotProps) {
 }
 
 export function GoalActivityChart({ points, goalNames, onEntryClick }: GoalActivityChartProps) {
+  const theme = useTheme();
+
   if (points.length === 0) {
     return (
       <Box sx={{ py: 4, textAlign: 'center' }}>
-        <Typography color="text.secondary">No progress entries yet this season.</Typography>
+        <Typography color="text.secondary">
+          {i18next.t('progress.graph.noData', 'No progress data available for this season.')}
+        </Typography>
       </Box>
     );
   }
@@ -66,14 +80,14 @@ export function GoalActivityChart({ points, goalNames, onEntryClick }: GoalActiv
   const chartHeight = Math.max(goalNames.length * 64 + 60, 160);
 
   const formatXTick = (timestamp: number) =>
-    new Date(timestamp).toLocaleDateString('default', { month: 'short', day: 'numeric' });
+    new Intl.DateTimeFormat('de-CH', { month: 'short', day: 'numeric' }).format(new Date(timestamp));
 
   const formatYTick = (index: number) => goalNames[index] ?? '';
 
   return (
     <ResponsiveContainer width="100%" height={chartHeight}>
       <ScatterChart margin={{ top: 16, right: 24, bottom: 16, left: 8 }}>
-        <CartesianGrid strokeDasharray="3 3" vertical={false} />
+        <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={theme.palette.divider} />
         <XAxis
           dataKey="x"
           type="number"
@@ -81,6 +95,9 @@ export function GoalActivityChart({ points, goalNames, onEntryClick }: GoalActiv
           tickFormatter={formatXTick}
           name="Date"
           scale="time"
+          tick={{ fontSize: 11, fill: theme.palette.text.secondary }}
+          tickLine={false}
+          axisLine={{ stroke: theme.palette.divider }}
         />
         <YAxis
           dataKey="y"
@@ -89,6 +106,9 @@ export function GoalActivityChart({ points, goalNames, onEntryClick }: GoalActiv
           ticks={goalNames.map((_, i) => i)}
           tickFormatter={formatYTick}
           width={110}
+          tick={{ fontSize: 11, fill: theme.palette.text.secondary }}
+          tickLine={false}
+          axisLine={{ stroke: theme.palette.divider }}
         />
         <Tooltip
           content={({ active, payload }) => {
@@ -97,8 +117,8 @@ export function GoalActivityChart({ points, goalNames, onEntryClick }: GoalActiv
             return (
               <Box sx={{ bgcolor: 'background.paper', border: 1, borderColor: 'divider', p: 1, borderRadius: 1 }}>
                 <Typography variant="caption" display="block" fontWeight="bold">{p.goalName}</Typography>
-                <Typography variant="caption" display="block">Rating: {p.rating}/5</Typography>
-                <Typography variant="caption" color="text.secondary">Click to open</Typography>
+                <Typography variant="caption" display="block">{i18next.t('progress.graph.rating', 'Rating')}: {p.rating}/5</Typography>
+                <Typography variant="caption" color="text.secondary">{i18next.t('progress.chart.clickToOpen', 'Click to open')}</Typography>
               </Box>
             );
           }}

--- a/src/components/progress/GoalActivityChart.tsx
+++ b/src/components/progress/GoalActivityChart.tsx
@@ -27,7 +27,9 @@ interface DotProps {
 
 function ActivityDot({ cx = 0, cy = 0, payload, onEntryClick }: DotProps) {
   if (!payload) return null;
-  const color = payload.isOnTrack ? '#1976d2' : '#e67e22';
+  const color = payload.isOnTrack
+    ? 'var(--palette-primary-main)'
+    : 'var(--palette-warning-main)';
   return (
     <g
       onClick={() => onEntryClick(payload.progressId, payload.reportId)}

--- a/src/components/progress/GoalActivityChart.tsx
+++ b/src/components/progress/GoalActivityChart.tsx
@@ -103,7 +103,9 @@ export function GoalActivityChart({ points, goalNames, onEntryClick }: GoalActiv
         />
         <Scatter
           data={points}
-          shape={(props: any) => <ActivityDot {...props} onEntryClick={onEntryClick} />}
+          shape={(props: { cx?: number; cy?: number; payload?: ScatterPoint }) =>
+            <ActivityDot {...props} onEntryClick={onEntryClick} />
+          }
         />
       </ScatterChart>
     </ResponsiveContainer>

--- a/src/components/progress/GoalActivityChart.tsx
+++ b/src/components/progress/GoalActivityChart.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import {
+  ResponsiveContainer,
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+} from 'recharts';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import { ScatterPoint } from '../../utils/chartUtils';
+
+interface GoalActivityChartProps {
+  points: ScatterPoint[];
+  goalNames: string[];
+  onEntryClick: (progressId: string, reportId: string) => void;
+}
+
+interface DotProps {
+  cx?: number;
+  cy?: number;
+  payload?: ScatterPoint;
+  onEntryClick: (progressId: string, reportId: string) => void;
+}
+
+function ActivityDot({ cx = 0, cy = 0, payload, onEntryClick }: DotProps) {
+  if (!payload) return null;
+  const color = payload.isOnTrack ? '#1976d2' : '#e67e22';
+  return (
+    <g
+      onClick={() => onEntryClick(payload.progressId, payload.reportId)}
+      style={{ cursor: 'pointer' }}
+      role="button"
+      aria-label={`Rating ${payload.rating} for ${payload.goalName}`}
+    >
+      <circle cx={cx} cy={cy} r={14} fill={color} opacity={0.85} />
+      <text
+        x={cx}
+        y={cy}
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fill="white"
+        fontSize={12}
+        fontWeight="bold"
+        pointerEvents="none"
+      >
+        {payload.rating}
+      </text>
+    </g>
+  );
+}
+
+export function GoalActivityChart({ points, goalNames, onEntryClick }: GoalActivityChartProps) {
+  if (points.length === 0) {
+    return (
+      <Box sx={{ py: 4, textAlign: 'center' }}>
+        <Typography color="text.secondary">No progress entries yet this season.</Typography>
+      </Box>
+    );
+  }
+
+  const chartHeight = Math.max(goalNames.length * 64 + 60, 160);
+
+  const formatXTick = (timestamp: number) =>
+    new Date(timestamp).toLocaleDateString('default', { month: 'short', day: 'numeric' });
+
+  const formatYTick = (index: number) => goalNames[index] ?? '';
+
+  return (
+    <ResponsiveContainer width="100%" height={chartHeight}>
+      <ScatterChart margin={{ top: 16, right: 24, bottom: 16, left: 8 }}>
+        <CartesianGrid strokeDasharray="3 3" vertical={false} />
+        <XAxis
+          dataKey="x"
+          type="number"
+          domain={['dataMin - 86400000', 'dataMax + 86400000']}
+          tickFormatter={formatXTick}
+          name="Date"
+          scale="time"
+        />
+        <YAxis
+          dataKey="y"
+          type="number"
+          domain={[-0.5, goalNames.length - 0.5]}
+          ticks={goalNames.map((_, i) => i)}
+          tickFormatter={formatYTick}
+          width={110}
+        />
+        <Tooltip
+          content={({ active, payload }) => {
+            if (!active || !payload?.length) return null;
+            const p = payload[0].payload as ScatterPoint;
+            return (
+              <Box sx={{ bgcolor: 'background.paper', border: 1, borderColor: 'divider', p: 1, borderRadius: 1 }}>
+                <Typography variant="caption" display="block" fontWeight="bold">{p.goalName}</Typography>
+                <Typography variant="caption" display="block">Rating: {p.rating}/5</Typography>
+                <Typography variant="caption" color="text.secondary">Click to open</Typography>
+              </Box>
+            );
+          }}
+        />
+        <Scatter
+          data={points}
+          shape={(props: any) => <ActivityDot {...props} onEntryClick={onEntryClick} />}
+        />
+      </ScatterChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/progress/MemberProgressView.tsx
+++ b/src/components/progress/MemberProgressView.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import { PersonalProgressView } from './PersonalProgressView';
+
+interface MemberProgressViewProps {
+  memberId: string;
+  memberName: string;
+  teamId: string;
+  seasonId: string;
+  onBack: () => void;
+}
+
+export function MemberProgressView({
+  memberId,
+  memberName,
+  teamId,
+  seasonId,
+  onBack,
+}: MemberProgressViewProps) {
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+        <Button
+          startIcon={<ArrowBackIcon />}
+          onClick={onBack}
+          size="small"
+          variant="text"
+        >
+          Team Overview
+        </Button>
+        <Typography variant="body2" color="text.secondary">
+          / {memberName}
+        </Typography>
+      </Box>
+
+      <Typography variant="caption" color="text.secondary" sx={{ mb: 2, display: 'block' }}>
+        Viewing {memberName}'s progress — read only
+      </Typography>
+
+      <PersonalProgressView
+        teamId={teamId}
+        seasonId={seasonId}
+        canParticipate={false}
+        authorId={memberId}
+      />
+    </Box>
+  );
+}

--- a/src/components/progress/PersonalProgressView.tsx
+++ b/src/components/progress/PersonalProgressView.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import { useNavigate } from 'react-router-dom';
+import i18next from 'i18next';
 import AddIcon from '@mui/icons-material/Add';
 import { GoalActivityChart } from './GoalActivityChart';
 import { EntryDrawer, EntryDrawerEntry } from './EntryDrawer';
 import { buildGoalActivityScatterData } from '../../utils/chartUtils';
+import { formatDate } from '../../utils/dateTime';
 import { useProgressReportStore } from '../../store/progressReports';
 import { useGoalStore } from '../../store/goals';
 
@@ -32,7 +35,7 @@ export function PersonalProgressView({
   const goals = goalList.goals;
 
   React.useEffect(() => {
-    fetchReports(seasonId, authorId ? { authorId } : ({} as any)).catch(() => {});
+    fetchReports(seasonId, authorId ? { authorId, limit: 100, sortOrder: 'desc' } : { limit: 100, sortOrder: 'desc' }).catch(() => {});
     fetchGoals(teamId, { limit: 100 } as any).catch(() => {});
   }, [seasonId, teamId, authorId]);
 
@@ -74,40 +77,40 @@ export function PersonalProgressView({
         )}
       </Box>
 
-      <GoalActivityChart
-        points={points}
-        goalNames={goalNames}
-        onEntryClick={handleEntryClick}
-      />
+      <Paper className="progress-chart-section" variant="outlined" sx={{ p: 2, mb: 3 }}>
+        <GoalActivityChart
+          points={points}
+          goalNames={goalNames}
+          onEntryClick={handleEntryClick}
+        />
+      </Paper>
 
-      <Box sx={{ mt: 3 }}>
-        <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+      <Paper className="progress-reports-section" variant="outlined" sx={{ p: 2 }}>
+        <Typography variant="subtitle2" color="text.secondary" className="progress-reports-title" gutterBottom>
           Reports
         </Typography>
-        {reportList.reports.map((report) => (
-          <Box
-            key={report.id}
-            sx={{
-              p: 1.5,
-              mb: 1,
-              border: 1,
-              borderColor: 'divider',
-              borderRadius: 1,
-              cursor: 'pointer',
-              '&:hover': { bgcolor: 'action.hover' },
-            }}
-            onClick={() => navigate(`/progress/${report.id}`)}
-            role="button"
-            tabIndex={0}
-            onKeyDown={(e) => e.key === 'Enter' && navigate(`/progress/${report.id}`)}
-          >
-            <Typography variant="body2" fontWeight="medium">{report.summary}</Typography>
-            <Typography variant="caption" color="text.secondary">
-              {new Date(report.createdAt).toLocaleDateString()}
-            </Typography>
-          </Box>
-        ))}
-      </Box>
+        {reportList.reports.length === 0 ? (
+          <Typography variant="body2" color="text.secondary" sx={{ py: 2, textAlign: 'center' }}>
+            {i18next.t('progress.chart.noReports', 'No reports yet this season.')}
+          </Typography>
+        ) : (
+          reportList.reports.map((report) => (
+            <Box
+              key={report.id}
+              className="progress-report-item"
+              onClick={() => navigate(`/progress/${report.id}`)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => e.key === 'Enter' && navigate(`/progress/${report.id}`)}
+            >
+              <Typography variant="body2" className="progress-report-item-summary">{report.summary}</Typography>
+              <Typography variant="caption" color="text.secondary" className="progress-report-item-date">
+                {formatDate(report.createdAt)}
+              </Typography>
+            </Box>
+          ))
+        )}
+      </Paper>
 
       <EntryDrawer
         entry={selectedEntry}

--- a/src/components/progress/PersonalProgressView.tsx
+++ b/src/components/progress/PersonalProgressView.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import { useNavigate } from 'react-router-dom';
+import AddIcon from '@mui/icons-material/Add';
+import { GoalActivityChart } from './GoalActivityChart';
+import { EntryDrawer, EntryDrawerEntry } from './EntryDrawer';
+import { buildGoalActivityScatterData } from '../../utils/chartUtils';
+import { useProgressReportStore } from '../../store/progressReports';
+import { useGoalStore } from '../../store/goals';
+
+interface PersonalProgressViewProps {
+  teamId: string;
+  seasonId: string;
+  canParticipate: boolean;
+  /** When provided, renders this member's data read-only instead of current user's */
+  authorId?: string;
+}
+
+export function PersonalProgressView({
+  teamId,
+  seasonId,
+  canParticipate,
+  authorId,
+}: PersonalProgressViewProps) {
+  const navigate = useNavigate();
+  const [selectedEntry, setSelectedEntry] = React.useState<EntryDrawerEntry | null>(null);
+
+  const { reportList, fetchReports } = useProgressReportStore();
+  const { goalList, fetchGoals } = useGoalStore();
+  const goals = goalList.goals;
+
+  React.useEffect(() => {
+    fetchReports(seasonId, authorId ? { authorId } : ({} as any)).catch(() => {});
+    fetchGoals(teamId, { limit: 100 } as any).catch(() => {});
+  }, [seasonId, teamId, authorId]);
+
+  const { points, goalNames } = buildGoalActivityScatterData(reportList.reports, goals);
+
+  const handleEntryClick = (progressId: string, reportId: string) => {
+    const report = reportList.reports.find((r) => r.id === reportId);
+    if (!report) return;
+    const entry = report.progress?.find((p) => p.id === progressId);
+    if (!entry) return;
+    const goal = goals.find((g) => g.id === entry.goalId);
+    setSelectedEntry({
+      id: entry.id,
+      goalId: entry.goalId,
+      goalName: goal?.title ?? entry.goalId,
+      rating: entry.rating,
+      details: entry.details,
+      reportId: report.id,
+      reportDate: report.createdAt,
+    });
+  };
+
+  const readonly = !!authorId;
+
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
+        <Typography variant="h6">
+          {authorId ? 'Progress' : 'My Progress'}
+        </Typography>
+        {canParticipate && !authorId && (
+          <Button
+            variant="contained"
+            startIcon={<AddIcon />}
+            onClick={() => navigate('/progress/create')}
+          >
+            New Report
+          </Button>
+        )}
+      </Box>
+
+      <GoalActivityChart
+        points={points}
+        goalNames={goalNames}
+        onEntryClick={handleEntryClick}
+      />
+
+      <Box sx={{ mt: 3 }}>
+        <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+          Reports
+        </Typography>
+        {reportList.reports.map((report) => (
+          <Box
+            key={report.id}
+            sx={{
+              p: 1.5,
+              mb: 1,
+              border: 1,
+              borderColor: 'divider',
+              borderRadius: 1,
+              cursor: 'pointer',
+              '&:hover': { bgcolor: 'action.hover' },
+            }}
+            onClick={() => navigate(`/progress/${report.id}`)}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => e.key === 'Enter' && navigate(`/progress/${report.id}`)}
+          >
+            <Typography variant="body2" fontWeight="medium">{report.summary}</Typography>
+            <Typography variant="caption" color="text.secondary">
+              {new Date(report.createdAt).toLocaleDateString()}
+            </Typography>
+          </Box>
+        ))}
+      </Box>
+
+      <EntryDrawer
+        entry={selectedEntry}
+        readonly={readonly}
+        onClose={() => setSelectedEntry(null)}
+      />
+    </Box>
+  );
+}

--- a/src/components/progress/TeamOverviewView.tsx
+++ b/src/components/progress/TeamOverviewView.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import Avatar from '@mui/material/Avatar';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardActionArea from '@mui/material/CardActionArea';
+import CardContent from '@mui/material/CardContent';
+import Grid from '@mui/material/Grid';
+import InputAdornment from '@mui/material/InputAdornment';
+import LinearProgress from '@mui/material/LinearProgress';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import SearchIcon from '@mui/icons-material/Search';
+import { useProgressReportStore } from '../../store/progressReports';
+
+interface TeamMember {
+  id: string;
+  name: string;
+  picture?: string;
+}
+
+interface TeamOverviewViewProps {
+  teamId: string;
+  seasonId: string;
+  members: TeamMember[];
+  onMemberSelect: (memberId: string) => void;
+}
+
+export function TeamOverviewView({
+  teamId: _teamId,
+  seasonId,
+  members,
+  onMemberSelect,
+}: TeamOverviewViewProps) {
+  const { reportList, fetchReports } = useProgressReportStore();
+  const [search, setSearch] = React.useState('');
+
+  React.useEffect(() => {
+    void Promise.resolve(fetchReports(seasonId, {})).catch(() => {});
+  }, [seasonId]);
+
+  const reportCountByAuthor = React.useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const report of reportList.reports) {
+      counts[report.authorId] = (counts[report.authorId] ?? 0) + 1;
+    }
+    return counts;
+  }, [reportList.reports]);
+
+  const maxReports = React.useMemo(() => {
+    const counts = Object.values(reportCountByAuthor);
+    return counts.length > 0 ? Math.max(...counts) : 1;
+  }, [reportCountByAuthor]);
+
+  const filteredMembers = React.useMemo(() => {
+    if (!search.trim()) return members;
+    const lower = search.toLowerCase();
+    return members.filter((m) => m.name.toLowerCase().includes(lower));
+  }, [members, search]);
+
+  return (
+    <Box>
+      <Box sx={{ mb: 2 }}>
+        <TextField
+          size="small"
+          fullWidth
+          placeholder="Search members..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon fontSize="small" color="action" />
+              </InputAdornment>
+            ),
+          }}
+        />
+      </Box>
+
+      <Grid container spacing={2}>
+        {filteredMembers.map((member) => {
+          const count = reportCountByAuthor[member.id] ?? 0;
+          const progress = maxReports > 0 ? (count / maxReports) * 100 : 0;
+          const reportLabel = count === 1 ? '1 report this season' : `${count} reports this season`;
+
+          return (
+            <Grid key={member.id} item xs={12} sm={6} md={4}>
+              <Card>
+                <CardActionArea onClick={() => onMemberSelect(member.id)}>
+                  <CardContent>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1.5 }}>
+                      <Avatar src={member.picture} alt={member.name}>
+                        {member.name.charAt(0).toUpperCase()}
+                      </Avatar>
+                      <Typography variant="subtitle1" fontWeight="medium">
+                        {member.name}
+                      </Typography>
+                    </Box>
+                    <Typography variant="body2" color="text.secondary" gutterBottom>
+                      {reportLabel}
+                    </Typography>
+                    <LinearProgress
+                      variant="determinate"
+                      value={progress}
+                      sx={{ borderRadius: 1 }}
+                    />
+                  </CardContent>
+                </CardActionArea>
+              </Card>
+            </Grid>
+          );
+        })}
+      </Grid>
+    </Box>
+  );
+}

--- a/src/components/progress/TeamOverviewView.tsx
+++ b/src/components/progress/TeamOverviewView.tsx
@@ -35,7 +35,7 @@ export function TeamOverviewView({
   const [search, setSearch] = React.useState('');
 
   React.useEffect(() => {
-    void Promise.resolve(fetchReports(seasonId, {})).catch(() => {});
+    void Promise.resolve(fetchReports(seasonId, { limit: 100 })).catch(() => {});
   }, [seasonId]);
 
   const reportCountByAuthor = React.useMemo(() => {
@@ -84,7 +84,7 @@ export function TeamOverviewView({
 
           return (
             <Grid key={member.id} item xs={12} sm={6} md={4}>
-              <Card>
+              <Card variant="outlined">
                 <CardActionArea onClick={() => onMemberSelect(member.id)}>
                   <CardContent>
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1.5 }}>

--- a/src/components/progress/__tests__/ContextSwitcher.test.tsx
+++ b/src/components/progress/__tests__/ContextSwitcher.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ContextSwitcher } from '../ContextSwitcher';
+
+const mockMembers = [
+  { id: 'user-1', name: 'Anna Müller' },
+  { id: 'user-2', name: 'Bob Klein' },
+];
+
+describe('ContextSwitcher', () => {
+  it('shows all three segments when canParticipate and canOversee are both true', () => {
+    render(
+      <ContextSwitcher
+        canParticipate={true}
+        canOversee={true}
+        value="personal"
+        onChange={jest.fn()}
+        members={mockMembers}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /my progress/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /team overview/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /member/i })).toBeInTheDocument();
+  });
+
+  it('does not render at all when only canParticipate is true', () => {
+    const { container } = render(
+      <ContextSwitcher
+        canParticipate={true}
+        canOversee={false}
+        value="personal"
+        onChange={jest.fn()}
+        members={[]}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('does not render at all when only canOversee is true', () => {
+    const { container } = render(
+      <ContextSwitcher
+        canParticipate={false}
+        canOversee={true}
+        value="team"
+        onChange={jest.fn()}
+        members={mockMembers}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('calls onChange with "personal" when My Progress is clicked', async () => {
+    const onChange = jest.fn();
+    render(
+      <ContextSwitcher
+        canParticipate={true}
+        canOversee={true}
+        value="team"
+        onChange={onChange}
+        members={mockMembers}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /my progress/i }));
+    expect(onChange).toHaveBeenCalledWith('personal');
+  });
+
+  it('shows member autocomplete when Member button is active', async () => {
+    render(
+      <ContextSwitcher
+        canParticipate={true}
+        canOversee={true}
+        value="member"
+        onChange={jest.fn()}
+        members={mockMembers}
+      />,
+    );
+    expect(screen.getByPlaceholderText(/search member/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/progress/__tests__/EntryDrawer.test.tsx
+++ b/src/components/progress/__tests__/EntryDrawer.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { EntryDrawer } from '../EntryDrawer';
+import { MemoryRouter } from 'react-router-dom';
+
+const mockEntry = {
+  id: 'entry-1',
+  goalId: 'goal-1',
+  goalName: 'Serve accuracy',
+  rating: 4,
+  details: 'Really focused this week.',
+  reportId: 'report-1',
+  reportDate: '2025-03-01T00:00:00Z',
+};
+
+function renderWithRouter(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe('EntryDrawer', () => {
+  it('renders nothing when entry is null', () => {
+    renderWithRouter(
+      <EntryDrawer entry={null} readonly={false} onClose={jest.fn()} />,
+    );
+    expect(screen.queryByText('Serve accuracy')).not.toBeInTheDocument();
+  });
+
+  it('shows goal name, rating, and details when entry is provided', () => {
+    renderWithRouter(
+      <EntryDrawer entry={mockEntry} readonly={false} onClose={jest.fn()} />,
+    );
+    expect(screen.getByText('Serve accuracy')).toBeInTheDocument();
+    expect(screen.getByText('4 / 5')).toBeInTheDocument();
+    expect(screen.getByText('Really focused this week.')).toBeInTheDocument();
+  });
+
+  it('hides the edit button in readonly mode but still shows open full report link', () => {
+    renderWithRouter(
+      <EntryDrawer entry={mockEntry} readonly={true} onClose={jest.fn()} />,
+    );
+    expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /open full report/i })).toBeInTheDocument();
+  });
+
+  it('calls onClose when the close button is clicked', async () => {
+    const onClose = jest.fn();
+    renderWithRouter(
+      <EntryDrawer entry={mockEntry} readonly={false} onClose={onClose} />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/progress/__tests__/GoalActivityChart.test.tsx
+++ b/src/components/progress/__tests__/GoalActivityChart.test.tsx
@@ -105,6 +105,6 @@ describe('GoalActivityChart', () => {
         onEntryClick={jest.fn()}
       />,
     );
-    expect(screen.getByText(/no progress entries/i)).toBeInTheDocument();
+    expect(screen.getByText(/no progress data/i)).toBeInTheDocument();
   });
 });

--- a/src/components/progress/__tests__/GoalActivityChart.test.tsx
+++ b/src/components/progress/__tests__/GoalActivityChart.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GoalActivityChart } from '../GoalActivityChart';
+
+// Recharts renders SVG — suppress ResizeObserver errors in jsdom
+global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} };
+
+// Mock Recharts so jsdom renders the chart children (including custom shapes)
+jest.mock('recharts', () => {
+  const React = require('react');
+  return {
+    ResponsiveContainer: ({ children }: any) => (
+      <div style={{ width: 800, height: 400 }}>{children}</div>
+    ),
+    ScatterChart: ({ children }: any) => <svg>{children}</svg>,
+    Scatter: ({ data, shape }: any) => (
+      <g>
+        {(data ?? []).map((point: any, i: number) =>
+          React.createElement('g', { key: i },
+            shape({ cx: 50 + i * 100, cy: 50 + i * 40, payload: point })
+          )
+        )}
+      </g>
+    ),
+    XAxis: ({ tickFormatter }: any) => <g className="x-axis" />,
+    YAxis: ({ ticks, tickFormatter }: any) => (
+      <g className="y-axis">
+        {(ticks ?? []).map((tick: number) => (
+          <text key={tick}>{tickFormatter(tick)}</text>
+        ))}
+      </g>
+    ),
+    CartesianGrid: () => <g />,
+    Tooltip: () => null,
+  };
+});
+
+const mockGoalNames = ['Serve accuracy', 'Jump height'];
+const mockPoints = [
+  {
+    x: new Date('2025-03-01').getTime(),
+    y: 0,
+    rating: 4,
+    progressId: 'entry-1',
+    reportId: 'report-1',
+    goalName: 'Serve accuracy',
+    isOnTrack: true,
+  },
+  {
+    x: new Date('2025-03-10').getTime(),
+    y: 1,
+    rating: 2,
+    progressId: 'entry-2',
+    reportId: 'report-2',
+    goalName: 'Jump height',
+    isOnTrack: false,
+  },
+];
+
+describe('GoalActivityChart', () => {
+  it('renders goal names as Y-axis labels', () => {
+    render(
+      <GoalActivityChart
+        points={mockPoints}
+        goalNames={mockGoalNames}
+        onEntryClick={jest.fn()}
+      />,
+    );
+    expect(screen.getByText('Serve accuracy')).toBeInTheDocument();
+    expect(screen.getByText('Jump height')).toBeInTheDocument();
+  });
+
+  it('renders a dot for each scatter point', () => {
+    render(
+      <GoalActivityChart
+        points={mockPoints}
+        goalNames={mockGoalNames}
+        onEntryClick={jest.fn()}
+      />,
+    );
+    // Each dot renders its rating as text
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('calls onEntryClick with progressId and reportId when a dot is clicked', async () => {
+    const onEntryClick = jest.fn();
+    render(
+      <GoalActivityChart
+        points={mockPoints}
+        goalNames={mockGoalNames}
+        onEntryClick={onEntryClick}
+      />,
+    );
+    await userEvent.click(screen.getByText('4'));
+    expect(onEntryClick).toHaveBeenCalledWith('entry-1', 'report-1');
+  });
+
+  it('renders an empty state message when there are no points', () => {
+    render(
+      <GoalActivityChart
+        points={[]}
+        goalNames={mockGoalNames}
+        onEntryClick={jest.fn()}
+      />,
+    );
+    expect(screen.getByText(/no progress entries/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/progress/__tests__/PersonalProgressView.test.tsx
+++ b/src/components/progress/__tests__/PersonalProgressView.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { PersonalProgressView } from '../PersonalProgressView';
+
+// Stub child components to keep tests focused
+jest.mock('../GoalActivityChart', () => ({
+  GoalActivityChart: () => <div data-testid="goal-activity-chart" />,
+}));
+jest.mock('../EntryDrawer', () => ({
+  EntryDrawer: () => null,
+}));
+
+// Mock the stores
+jest.mock('../../../store/progressReports', () => ({
+  useProgressReportStore: () => ({
+    reportList: { reports: [], count: 0 },
+    fetchReports: jest.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+jest.mock('../../../store/goals', () => ({
+  useGoalStore: jest.fn(() => ({
+    goalList: { goals: [] },
+    fetchGoals: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+describe('PersonalProgressView', () => {
+  it('renders the goal activity chart', () => {
+    render(
+      <MemoryRouter>
+        <PersonalProgressView teamId="team-1" seasonId="season-1" canParticipate={true} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId('goal-activity-chart')).toBeInTheDocument();
+  });
+
+  it('shows the New Report button when canParticipate is true', () => {
+    render(
+      <MemoryRouter>
+        <PersonalProgressView teamId="team-1" seasonId="season-1" canParticipate={true} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole('button', { name: /new report/i })).toBeInTheDocument();
+  });
+
+  it('hides the New Report button when canParticipate is false', () => {
+    render(
+      <MemoryRouter>
+        <PersonalProgressView teamId="team-1" seasonId="season-1" canParticipate={false} />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByRole('button', { name: /new report/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/progress/__tests__/TeamOverviewView.test.tsx
+++ b/src/components/progress/__tests__/TeamOverviewView.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TeamOverviewView } from '../TeamOverviewView';
+
+jest.mock('../../../store/progressReports', () => ({
+  useProgressReportStore: () => ({
+    reportList: {
+      reports: [
+        { id: 'r1', authorId: 'user-1', createdAt: '2025-03-01T00:00:00Z', summary: 'S1', progress: [] },
+        { id: 'r2', authorId: 'user-2', createdAt: '2025-03-05T00:00:00Z', summary: 'S2', progress: [] },
+      ],
+    },
+    fetchReports: jest.fn(),
+  }),
+}));
+
+const mockMembers = [
+  { id: 'user-1', name: 'Anna Müller', picture: undefined },
+  { id: 'user-2', name: 'Bob Klein', picture: undefined },
+];
+
+describe('TeamOverviewView', () => {
+  it('renders a card for each team member', () => {
+    render(
+      <TeamOverviewView
+        teamId="team-1"
+        seasonId="season-1"
+        members={mockMembers}
+        onMemberSelect={jest.fn()}
+      />,
+    );
+    expect(screen.getByText('Anna Müller')).toBeInTheDocument();
+    expect(screen.getByText('Bob Klein')).toBeInTheDocument();
+  });
+
+  it('shows the report count per member', () => {
+    render(
+      <TeamOverviewView
+        teamId="team-1"
+        seasonId="season-1"
+        members={mockMembers}
+        onMemberSelect={jest.fn()}
+      />,
+    );
+    // Anna has 1 report, Bob has 1 report
+    expect(screen.getAllByText(/1 report/i)).toHaveLength(2);
+  });
+
+  it('calls onMemberSelect with memberId when a member card is clicked', async () => {
+    const onMemberSelect = jest.fn();
+    render(
+      <TeamOverviewView
+        teamId="team-1"
+        seasonId="season-1"
+        members={mockMembers}
+        onMemberSelect={onMemberSelect}
+      />,
+    );
+    await userEvent.click(screen.getByText('Anna Müller'));
+    expect(onMemberSelect).toHaveBeenCalledWith('user-1');
+  });
+
+  it('filters members when search input is used', async () => {
+    render(
+      <TeamOverviewView
+        teamId="team-1"
+        seasonId="season-1"
+        members={mockMembers}
+        onMemberSelect={jest.fn()}
+      />,
+    );
+    await userEvent.type(screen.getByPlaceholderText(/search members/i), 'Anna');
+    expect(screen.getByText('Anna Müller')).toBeInTheDocument();
+    expect(screen.queryByText('Bob Klein')).not.toBeInTheDocument();
+  });
+});

--- a/src/hooks/__tests__/useProgressReportPermissions.test.ts
+++ b/src/hooks/__tests__/useProgressReportPermissions.test.ts
@@ -1,0 +1,36 @@
+import { renderHook } from '@testing-library/react';
+import { useProgressReportPermissions } from '../useProgressReportPermissions';
+import { usePermission } from '../usePermission';
+
+jest.mock('../usePermission');
+const mockUsePermission = usePermission as jest.MockedFunction<typeof usePermission>;
+
+describe('useProgressReportPermissions', () => {
+  it('returns canParticipate=true when individual_goals:write permission exists', () => {
+    mockUsePermission.mockImplementation((p) => p === 'individual_goals:write');
+    const { result } = renderHook(() => useProgressReportPermissions());
+    expect(result.current.canParticipate).toBe(true);
+    expect(result.current.canOversee).toBe(false);
+  });
+
+  it('returns canOversee=true when members:read permission exists', () => {
+    mockUsePermission.mockImplementation((p) => p === 'members:read');
+    const { result } = renderHook(() => useProgressReportPermissions());
+    expect(result.current.canParticipate).toBe(false);
+    expect(result.current.canOversee).toBe(true);
+  });
+
+  it('returns both flags true when user has both permissions', () => {
+    mockUsePermission.mockReturnValue(true);
+    const { result } = renderHook(() => useProgressReportPermissions());
+    expect(result.current.canParticipate).toBe(true);
+    expect(result.current.canOversee).toBe(true);
+  });
+
+  it('returns both flags false when user has neither permission', () => {
+    mockUsePermission.mockReturnValue(false);
+    const { result } = renderHook(() => useProgressReportPermissions());
+    expect(result.current.canParticipate).toBe(false);
+    expect(result.current.canOversee).toBe(false);
+  });
+});

--- a/src/hooks/useProgressReportPermissions.ts
+++ b/src/hooks/useProgressReportPermissions.ts
@@ -1,0 +1,14 @@
+import { usePermission } from './usePermission';
+
+export interface ProgressReportPermissions {
+  /** User can create/edit their own progress reports */
+  canParticipate: boolean;
+  /** User can view all team members' progress reports */
+  canOversee: boolean;
+}
+
+export function useProgressReportPermissions(): ProgressReportPermissions {
+  const canParticipate = usePermission('individual_goals:write');
+  const canOversee = usePermission('members:read');
+  return { canParticipate, canOversee };
+}

--- a/src/i18n/de/translation.json
+++ b/src/i18n/de/translation.json
@@ -565,7 +565,12 @@
       "selectSeason": "Wählen Sie eine Saison, um den Fortschrittsgraphen anzuzeigen.",
       "manageReports": "Berichte verwalten",
       "rating": "Bewertung"
-    }
+    },
+    "chart": {
+      "clickToOpen": "Zum Öffnen klicken",
+      "noReports": "Noch keine Berichte für diese Saison."
+    },
+    "selectMember": "Wählen Sie ein Mitglied aus der Liste oben aus, um dessen Fortschritt anzuzeigen."
   },
   "members": {
     "title": "Teammitglieder",

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -571,7 +571,12 @@
       "selectSeason": "Select a season to view the progress graph.",
       "manageReports": "Manage Reports",
       "rating": "Rating"
-    }
+    },
+    "chart": {
+      "clickToOpen": "Click to open",
+      "noReports": "No reports yet this season."
+    },
+    "selectMember": "Select a member from the list above to view their progress."
   },
   "members": {
     "title": "Team Members",

--- a/src/pages/user/Progress.tsx
+++ b/src/pages/user/Progress.tsx
@@ -1,95 +1,42 @@
-import React, { useState, useMemo } from 'react';
-import {
-  Avatar, Box, Button, Chip, Paper, Typography, MenuItem, TextField,
-  Dialog, DialogTitle, DialogContent, DialogActions, useTheme, useMediaQuery,
-  InputAdornment,
-} from '@mui/material';
-import SearchIcon from '@mui/icons-material/Search';
-import FilterListIcon from '@mui/icons-material/FilterList';
-import ClearIcon from '@mui/icons-material/Clear';
-import { useNavigate } from 'react-router-dom';
-import {
-  ResponsiveContainer, LineChart, Line, XAxis, YAxis, CartesianGrid,
-  Tooltip as RechartsTooltip, Legend,
-} from 'recharts';
-import { useProgressReportStore } from '../../store/progressReports';
+import React from 'react';
+import Box from '@mui/material/Box';
+import Container from '@mui/material/Container';
+import MenuItem from '@mui/material/MenuItem';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import { useProgressReportPermissions } from '../../hooks/useProgressReportPermissions';
+import { ContextSwitcher } from '../../components/progress/ContextSwitcher';
+import { PersonalProgressView } from '../../components/progress/PersonalProgressView';
+import { TeamOverviewView } from '../../components/progress/TeamOverviewView';
+import { MemberProgressView } from '../../components/progress/MemberProgressView';
 import { useSeasonStore } from '../../store/seasons';
-import { useCognitoUserStore } from '../../store/cognitoUser';
-import { usePermission } from '../../hooks/usePermission';
-import { useGoalStore } from '../../store/goals';
 import { useTeamStore } from '../../store/teams';
-import { IProgressReport, ISeason } from '../../store/types';
-import { formatDate, formatDateTime } from '../../utils/dateTime';
-import { buildProgressChartData, GOAL_COLORS } from '../../utils/chartUtils';
+import { useCognitoUserStore } from '../../store/cognitoUser';
+import { ISeason } from '../../store/types';
 import i18next from 'i18next';
-import IconButton from '@mui/material/IconButton';
-
-// Custom tooltip
-const CustomTooltip = ({ active, payload, label }: any) => {
-  if (!active || !payload?.length) return null;
-  return (
-    <Paper sx={{ p: 1.5, maxWidth: 220 }} elevation={4}>
-      <Typography variant="caption" color="text.secondary" display="block" mb={0.5}>
-        {label}
-      </Typography>
-      {payload.map((entry: any) => (
-        <Box key={entry.dataKey} display="flex" alignItems="center" gap={1} mb={0.25}>
-          <Box sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: entry.color }} />
-          <Typography variant="caption">
-            {entry.name}: <strong>{entry.value}/5</strong>
-          </Typography>
-        </Box>
-      ))}
-      {payload[0]?.payload?.summary && (
-        <Typography variant="caption" color="text.secondary" display="block" mt={0.5} sx={{ fontStyle: 'italic' }}>
-          {payload[0].payload.summary.length > 40
-            ? payload[0].payload.summary.slice(0, 38) + '…'
-            : payload[0].payload.summary}
-        </Typography>
-      )}
-    </Paper>
-  );
-};
 
 export function Progress() {
-  const fetchReports = useProgressReportStore((s) => s.fetchReports);
-  const deleteReport = useProgressReportStore((s) => s.deleteReport);
-  const reports = useProgressReportStore((s) => s.reportList.reports) || [];
-  const fetchSeasons = useSeasonStore((s) => s.fetchSeasons);
-  const seasons = useSeasonStore((s) => s.seasonList.seasons) || [] as ISeason[];
   const selectedTeam = useCognitoUserStore((s) => s.selectedTeam);
-  const currentUser = useCognitoUserStore((s) => s.user);
-  const fetchGoals = useGoalStore((s) => s.fetchGoals);
-  const goals = useGoalStore((s) => s.goalList.goals) || [];
+  const teamId = selectedTeam?.team?.id ?? '';
+
+  const fetchSeasons = useSeasonStore((s) => s.fetchSeasons);
+  const seasons = useSeasonStore((s) => s.seasonList.seasons) ?? ([] as ISeason[]);
+
   const fetchTeamMembers = useTeamStore((s) => s.fetchTeamMembers);
-  const teamMembers = useTeamStore((s) => s.teamMembers) || [];
-  const navigate = useNavigate();
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const teamMembers = useTeamStore((s) => s.teamMembers) ?? [];
 
-  const teamId = selectedTeam?.team?.id || '';
-  const canCreate = usePermission('progress_reports:write');
-  const canEdit = usePermission('progress_reports:write');
-  const canDelete = usePermission('progress_reports:delete');
-
-  const [allowFetch, setAllowFetch] = useState<boolean>(!!selectedTeam);
-  React.useEffect(() => setAllowFetch(!!selectedTeam), [selectedTeam]);
+  const { canParticipate, canOversee } = useProgressReportPermissions();
 
   const [selectedSeasonId, setSelectedSeasonId] = React.useState<string | null>(null);
-  const [hiddenGoalIds, setHiddenGoalIds] = useState<Set<string>>(new Set());
-  const [deleteOpen, setDeleteOpen] = useState(false);
-  const [currentReport, setCurrentReport] = useState<IProgressReport | null>(null);
-  const [actionLoading, setActionLoading] = useState(false);
-  const [showAllReports, setShowAllReports] = useState(false);
-  const [searchText, setSearchText] = useState('');
-  const [filterFrom, setFilterFrom] = useState('');
-  const [filterTo, setFilterTo] = useState('');
-  const [showFilters, setShowFilters] = useState(false);
+
+  // 'personal' | 'team' | '<memberId>'
+  const [viewMode, setViewMode] = React.useState<string>(() =>
+    canParticipate ? 'personal' : 'team',
+  );
 
   React.useEffect(() => {
     if (teamId) {
       fetchSeasons(teamId, { teamId });
-      fetchTeamMembers(teamId, { limit: 100 } as any).catch(() => {});
     }
   }, [teamId]);
 
@@ -103,370 +50,103 @@ export function Progress() {
       const bDate = b.startDate || b.createdAt || '';
       return new Date(bDate).getTime() - new Date(aDate).getTime();
     });
-    setSelectedSeasonId(prev => prev || (sorted[0] && sorted[0].id) || null);
+    setSelectedSeasonId((prev) => prev || (sorted[0] && sorted[0].id) || null);
   }, [seasons]);
 
   React.useEffect(() => {
-    if (selectedSeasonId && allowFetch) {
-      fetchReports(selectedSeasonId, { limit: 100 } as any).catch(() => {});
+    if (canOversee && teamId) {
+      fetchTeamMembers(teamId, { limit: 100 } as any).catch(() => {});
     }
-  }, [selectedSeasonId, allowFetch]);
+  }, [canOversee, teamId]);
 
+  // Oversight-only users should never land on personal view
   React.useEffect(() => {
-    if (teamId && allowFetch) {
-      fetchGoals(teamId, { limit: 100 } as any).catch(() => {});
+    if (!canParticipate && canOversee && viewMode === 'personal') {
+      setViewMode('team');
     }
-  }, [teamId, allowFetch]);
+  }, [canParticipate, canOversee]);
 
-  const resolveAuthor = (id: string): string => {
-    if (currentUser?.id === id) return currentUser.name || currentUser.preferredUsername || currentUser.email || id;
-    const member = teamMembers.find(m => m.id === id);
-    return member?.name || member?.preferredUsername || member?.email || id;
-  };
+  const members = teamMembers.map((m) => ({
+    id: m.id,
+    name: m.name || m.preferredUsername || m.email,
+    picture: m.picture,
+  }));
 
-  const toggleGoal = (goalId: string) => {
-    setHiddenGoalIds(prev => {
-      const next = new Set(prev);
-      if (next.has(goalId)) next.delete(goalId);
-      else next.add(goalId);
-      return next;
-    });
-  };
-
-  const { data: chartData, chartGoals } = useMemo(
-    () => buildProgressChartData(reports, goals, hiddenGoalIds),
-    [reports, goals, hiddenGoalIds]
-  );
-
-  // Goals with data for filter chips
-  const goalsWithData = useMemo(() => {
-    const goalIdsWithData = new Set<string>();
-    reports.forEach(r => r.progress?.forEach(p => goalIdsWithData.add(p.goalId)));
-    return goals.filter(g => goalIdsWithData.has(g.id));
-  }, [goals, reports]);
-
-  // Report list filters
-  const sortedReports = useMemo(
-    () => [...reports].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
-    [reports]
-  );
-
-  const filteredReports = useMemo(() => {
-    return sortedReports.filter(r => {
-      if (searchText && !r.summary?.toLowerCase().includes(searchText.toLowerCase())) return false;
-      if (filterFrom && new Date(r.createdAt) < new Date(filterFrom)) return false;
-      if (filterTo && new Date(r.createdAt) > new Date(filterTo + 'T23:59:59')) return false;
-      return true;
-    });
-  }, [sortedReports, searchText, filterFrom, filterTo]);
-
-  const displayedReports = showAllReports ? filteredReports : filteredReports.slice(0, 5);
-  const hasMoreReports = filteredReports.length > 5;
-
-  const hasActiveFilters = searchText || filterFrom || filterTo;
-
-  const clearFilters = () => {
-    setSearchText('');
-    setFilterFrom('');
-    setFilterTo('');
-    setShowAllReports(false);
-  };
-
-  const onDelete = async () => {
-    if (!currentReport || !selectedSeasonId) return;
-    setActionLoading(true);
-    try {
-      await deleteReport(currentReport.seasonId, currentReport.id);
-      setDeleteOpen(false);
-    } finally {
-      setActionLoading(false);
-    }
-  };
+  const selectedMember = members.find((m) => m.id === viewMode);
+  const isPersonal = viewMode === 'personal';
+  const isTeam = viewMode === 'team';
+  const isMember = !isPersonal && !isTeam;
 
   return (
-    <Box sx={{ pb: { xs: 2, sm: 0 } }}>
-      {/* Graph Paper */}
-      <Paper sx={{ borderRadius: 3, overflow: 'hidden' }}>
-        <Box p={{ xs: 2, sm: 3 }}>
-          <Box display="flex" alignItems="center" justifyContent="space-between" flexWrap="wrap" gap={1}>
-            <Typography variant="h5" fontWeight={600}>
-              {i18next.t('progress.title', 'Progress Reports')}
-            </Typography>
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={() => navigate('/progress/create')}
-              disabled={!selectedSeasonId}
-              sx={{ borderRadius: 2 }}
-            >
-              {i18next.t('progress.createTitle', 'Create Progress Report')}
-            </Button>
-          </Box>
+    <Container maxWidth="lg" sx={{ py: 3 }}>
+      {/* Season selector */}
+      <Box sx={{ mb: 3, display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+        <Typography variant="h5" fontWeight={600} sx={{ flex: 1 }}>
+          {i18next.t('progress.title', 'Progress Reports')}
+        </Typography>
+        <TextField
+          select
+          size="small"
+          value={selectedSeasonId ?? ''}
+          label={i18next.t('user.goals.selectSeason', 'Season')}
+          onChange={(e) => setSelectedSeasonId(e.target.value)}
+          sx={{ minWidth: 200 }}
+          disabled={seasons.length === 0}
+        >
+          {seasons.map((s) => (
+            <MenuItem key={s.id} value={s.id}>
+              {s.name}
+            </MenuItem>
+          ))}
+        </TextField>
+      </Box>
 
-          {/* Season selector */}
-          <Box mt={2}>
-            <TextField
-              select
-              size="small"
-              value={selectedSeasonId ?? ''}
-              label={i18next.t('user.goals.selectSeason', 'Season')}
-              onChange={(e) => setSelectedSeasonId(e.target.value)}
-              sx={{ minWidth: 200 }}
-            >
-              {seasons.map((s) => (
-                <MenuItem key={s.id} value={s.id}>{s.name}</MenuItem>
-              ))}
-            </TextField>
-          </Box>
+      <ContextSwitcher
+        canParticipate={canParticipate}
+        canOversee={canOversee}
+        value={viewMode}
+        onChange={setViewMode}
+        members={members}
+      />
 
-          {/* Goal filter chips */}
-          {goalsWithData.length > 0 && (
-            <Box mt={2} display="flex" gap={1} flexWrap="wrap" alignItems="center">
-              <Typography variant="caption" color="text.secondary" sx={{ mr: 0.5 }}>
-                {i18next.t('progress.goals', 'Goals:')}
-              </Typography>
-              {goalsWithData.map((g, idx) => (
-                <Chip
-                  key={g.id}
-                  label={g.title}
-                  size="small"
-                  variant={hiddenGoalIds.has(g.id) ? 'outlined' : 'filled'}
-                  onClick={() => toggleGoal(g.id)}
-                  sx={hiddenGoalIds.has(g.id)
-                    ? { borderRadius: 1.5 }
-                    : { bgcolor: GOAL_COLORS[idx % GOAL_COLORS.length], color: '#fff', borderRadius: 1.5 }
-                  }
-                />
-              ))}
-            </Box>
+      {!selectedSeasonId ? (
+        <Box sx={{ py: 6, textAlign: 'center' }}>
+          <Typography color="text.secondary">
+            {i18next.t('progress.graph.selectSeason', 'Select a season to view progress.')}
+          </Typography>
+        </Box>
+      ) : (
+        <Box>
+          {isPersonal && (
+            <PersonalProgressView
+              teamId={teamId}
+              seasonId={selectedSeasonId}
+              canParticipate={canParticipate}
+            />
           )}
 
-          {/* Chart */}
-          <Box mt={3}>
-            {!selectedSeasonId || !allowFetch ? (
-              <Typography variant="body2" color="text.secondary">
-                {i18next.t('progress.graph.selectSeason', 'Select a season to view the progress graph.')}
-              </Typography>
-            ) : chartGoals.length === 0 ? (
-              <Typography variant="body2" color="text.secondary">
-                {reports.length > 0
-                  ? i18next.t('progress.graph.noDataWithReports', 'Progress data loading — if graph remains empty, progress entries may not yet be linked to goals.')
-                  : i18next.t('progress.graph.noData', 'No progress data available for this season.')}
-              </Typography>
-            ) : (
-              <ResponsiveContainer width="100%" height={isMobile ? 240 : 320}>
-                <LineChart data={chartData} margin={{ top: 8, right: 16, left: 0, bottom: 8 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke={theme.palette.divider} />
-                  <XAxis
-                    dataKey="dateLabel"
-                    tick={{ fontSize: 11, fill: theme.palette.text.secondary }}
-                    tickLine={false}
-                    axisLine={{ stroke: theme.palette.divider }}
-                  />
-                  <YAxis hide />
-                  <RechartsTooltip content={<CustomTooltip />} />
-                  <Legend
-                    wrapperStyle={{ fontSize: 12, paddingTop: 8 }}
-                    iconType="circle"
-                    iconSize={10}
-                  />
-                  {chartGoals.map((g) => (
-                    <Line
-                      key={g.id}
-                      type="monotone"
-                      dataKey={g.id}
-                      name={g.title}
-                      stroke={g.color}
-                      strokeWidth={2}
-                      connectNulls={false}
-                      dot={{ r: 4, strokeWidth: 2, stroke: '#fff' }}
-                      activeDot={{
-                        r: 7,
-                        strokeWidth: 2,
-                        stroke: '#fff',
-                        style: { cursor: 'pointer' },
-                        onClick: (_: any, payload: any) => {
-                          if (payload?.payload?.reportId)
-                            navigate(`/progress/${payload.payload.reportId}`, { state: { seasonId: selectedSeasonId } });
-                        },
-                      }}
-                    />
-                  ))}
-                </LineChart>
-              </ResponsiveContainer>
-            )}
-          </Box>
-
-        </Box>
-      </Paper>
-
-      {/* Report List Paper */}
-      {reports.length > 0 && (
-        <Paper sx={{ mt: 2, borderRadius: 3, overflow: 'hidden' }}>
-          <Box p={{ xs: 2, sm: 3 }}>
-            <Box display="flex" alignItems="center" justifyContent="space-between" flexWrap="wrap" gap={1} mb={2}>
-              <Typography variant="h6" fontWeight={600}>
-                {i18next.t('progress.reports', 'Progress Reports')}
-              </Typography>
-              <Box display="flex" gap={1} alignItems="center">
-                {hasActiveFilters && (
-                  <Chip
-                    label={i18next.t('common.clearFilters', 'Clear filters')}
-                    size="small"
-                    onDelete={clearFilters}
-                    deleteIcon={<ClearIcon />}
-                    sx={{ borderRadius: 1.5 }}
-                  />
-                )}
-                <IconButton
-                  size="small"
-                  onClick={() => setShowFilters(v => !v)}
-                  color={showFilters ? 'primary' : 'default'}
-                  title={i18next.t('common.filters', 'Filters')}
-                >
-                  <FilterListIcon fontSize="small" />
-                </IconButton>
-              </Box>
-            </Box>
-
-            {/* Search bar (always visible) */}
-            <TextField
-              size="small"
-              fullWidth
-              placeholder={i18next.t('progress.searchPlaceholder', 'Search by summary...')}
-              value={searchText}
-              onChange={(e) => { setSearchText(e.target.value); setShowAllReports(false); }}
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <SearchIcon fontSize="small" color="action" />
-                  </InputAdornment>
-                ),
-                endAdornment: searchText ? (
-                  <InputAdornment position="end">
-                    <IconButton size="small" onClick={() => setSearchText('')}><ClearIcon fontSize="small" /></IconButton>
-                  </InputAdornment>
-                ) : null,
-              }}
-              sx={{ mb: 2, '& .MuiOutlinedInput-root': { borderRadius: 2 } }}
+          {isTeam && (
+            <TeamOverviewView
+              teamId={teamId}
+              seasonId={selectedSeasonId}
+              members={members}
+              onMemberSelect={(memberId) => setViewMode(memberId)}
             />
+          )}
 
-            {/* Expanded filters */}
-            {showFilters && (
-              <Box display="flex" gap={2} flexWrap="wrap" mb={2}>
-                <TextField
-                  size="small"
-                  type="date"
-                  label={i18next.t('progress.filterFrom', 'From Date')}
-                  value={filterFrom}
-                  onChange={(e) => { setFilterFrom(e.target.value); setShowAllReports(false); }}
-                  InputLabelProps={{ shrink: true }}
-                  sx={{ minWidth: 150, '& .MuiOutlinedInput-root': { borderRadius: 2 } }}
-                />
-                <TextField
-                  size="small"
-                  type="date"
-                  label={i18next.t('progress.filterTo', 'To Date')}
-                  value={filterTo}
-                  onChange={(e) => { setFilterTo(e.target.value); setShowAllReports(false); }}
-                  InputLabelProps={{ shrink: true }}
-                  sx={{ minWidth: 150, '& .MuiOutlinedInput-root': { borderRadius: 2 } }}
-                />
-              </Box>
-            )}
-
-            <Box display="flex" flexDirection="column" gap={1}>
-              {displayedReports.map(r => {
-                const isAuthor = currentUser?.id === r.authorId;
-                const canDeleteThis = isAuthor || canDelete;
-                const authorName = r.authorName || resolveAuthor(r.authorId);
-                const authorPicture = r.authorPicture;
-                return (
-                  <Box
-                    key={r.id}
-                    display="flex"
-                    alignItems="center"
-                    gap={2}
-                    py={1.5}
-                    px={1}
-                    sx={{
-                      borderRadius: 2,
-                      border: '1px solid',
-                      borderColor: 'divider',
-                      transition: 'background-color 0.15s',
-                      '&:hover': { bgcolor: 'action.hover' },
-                    }}
-                  >
-                    <Avatar src={authorPicture || undefined} sx={{ width: 36, height: 36, flexShrink: 0 }}>
-                      {authorName[0]}
-                    </Avatar>
-                    <Box flex={1} minWidth={0}>
-                      <Typography variant="body2" fontWeight={500} noWrap>
-                        {r.summary.length > 60 ? r.summary.slice(0, 60) + '…' : r.summary}
-                      </Typography>
-                      <Typography variant="caption" color="text.secondary">
-                        {authorName} · {formatDateTime(r.createdAt)}
-                      </Typography>
-                    </Box>
-                    <Box display="flex" gap={1} flexShrink={0}>
-                      <Button
-                        size="small"
-                        variant="outlined"
-                        sx={{ borderRadius: 1.5 }}
-                        onClick={() => navigate(`/progress/${r.id}`, { state: { seasonId: selectedSeasonId } })}
-                      >
-                        {i18next.t('common.view', 'View')}
-                      </Button>
-                      {canDeleteThis && (
-                        <Button
-                          size="small"
-                          variant="contained"
-                          color="error"
-                          sx={{ borderRadius: 1.5 }}
-                          onClick={() => { setCurrentReport(r); setDeleteOpen(true); }}
-                        >
-                          {i18next.t('progress.delete', 'Delete')}
-                        </Button>
-                      )}
-                    </Box>
-                  </Box>
-                );
-              })}
-            </Box>
-
-            {!showAllReports && hasMoreReports && (
-              <Box mt={1.5}>
-                <Button
-                  size="small"
-                  variant="text"
-                  sx={{ borderRadius: 2 }}
-                  onClick={() => setShowAllReports(true)}
-                >
-                  {i18next.t('progress.viewMoreReports', 'View More Progress Reports')}
-                </Button>
-              </Box>
-            )}
-          </Box>
-        </Paper>
+          {isMember && selectedMember && (
+            <MemberProgressView
+              memberId={selectedMember.id}
+              memberName={selectedMember.name}
+              teamId={teamId}
+              seasonId={selectedSeasonId}
+              onBack={() => setViewMode('team')}
+            />
+          )}
+        </Box>
       )}
-
-      {/* Delete Dialog */}
-      <Dialog
-        open={deleteOpen}
-        onClose={() => setDeleteOpen(false)}
-        PaperProps={{ sx: { borderRadius: 3 } }}
-      >
-        <DialogTitle>{i18next.t('progress.delete', 'Delete')}</DialogTitle>
-        <DialogContent>
-          <Typography>{i18next.t('progress.deleteConfirm', 'Are you sure you want to delete this progress report?')}</Typography>
-        </DialogContent>
-        <DialogActions sx={{ px: 3, pb: 2 }}>
-          <Button onClick={() => setDeleteOpen(false)} sx={{ borderRadius: 2 }}>{i18next.t('common.cancel', 'Cancel')}</Button>
-          <Button variant="contained" color="error" sx={{ borderRadius: 2 }} onClick={onDelete} disabled={actionLoading}>
-            {i18next.t('progress.delete', 'Delete')}
-          </Button>
-        </DialogActions>
-      </Dialog>
-    </Box>
+    </Container>
   );
 }
+
+export default Progress;

--- a/src/pages/user/Progress.tsx
+++ b/src/pages/user/Progress.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import MenuItem from '@mui/material/MenuItem';
+import Paper from '@mui/material/Paper';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { useProgressReportPermissions } from '../../hooks/useProgressReportPermissions';
@@ -79,72 +80,82 @@ export function Progress() {
 
   return (
     <Container maxWidth="lg" sx={{ py: 3 }}>
-      {/* Season selector */}
-      <Box sx={{ mb: 3, display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
-        <Typography variant="h5" fontWeight={600} sx={{ flex: 1 }}>
-          {i18next.t('progress.title', 'Progress Reports')}
-        </Typography>
-        <TextField
-          select
-          size="small"
-          value={selectedSeasonId ?? ''}
-          label={i18next.t('user.goals.selectSeason', 'Season')}
-          onChange={(e) => setSelectedSeasonId(e.target.value)}
-          sx={{ minWidth: 200 }}
-          disabled={seasons.length === 0}
-        >
-          {seasons.map((s) => (
-            <MenuItem key={s.id} value={s.id}>
-              {s.name}
-            </MenuItem>
-          ))}
-        </TextField>
-      </Box>
-
-      <ContextSwitcher
-        canParticipate={canParticipate}
-        canOversee={canOversee}
-        value={viewMode}
-        onChange={setViewMode}
-        members={members}
-      />
-
-      {!selectedSeasonId ? (
-        <Box sx={{ py: 6, textAlign: 'center' }}>
-          <Typography color="text.secondary">
-            {i18next.t('progress.graph.selectSeason', 'Select a season to view progress.')}
+      <Paper className="progress-page" sx={{ p: 3 }}>
+        {/* Season selector */}
+        <Box sx={{ mb: 3, display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+          <Typography variant="h5" fontWeight={600} sx={{ flex: 1 }}>
+            {i18next.t('progress.title', 'Progress Reports')}
           </Typography>
+          <TextField
+            select
+            size="small"
+            value={selectedSeasonId ?? ''}
+            label={i18next.t('user.goals.selectSeason', 'Season')}
+            onChange={(e) => setSelectedSeasonId(e.target.value)}
+            sx={{ minWidth: 200 }}
+            disabled={seasons.length === 0}
+          >
+            {seasons.map((s) => (
+              <MenuItem key={s.id} value={s.id}>
+                {s.name}
+              </MenuItem>
+            ))}
+          </TextField>
         </Box>
-      ) : (
-        <Box>
-          {isPersonal && (
-            <PersonalProgressView
-              teamId={teamId}
-              seasonId={selectedSeasonId}
-              canParticipate={canParticipate}
-            />
-          )}
 
-          {isTeam && (
-            <TeamOverviewView
-              teamId={teamId}
-              seasonId={selectedSeasonId}
-              members={members}
-              onMemberSelect={(memberId) => setViewMode(memberId)}
-            />
-          )}
+        <ContextSwitcher
+          canParticipate={canParticipate}
+          canOversee={canOversee}
+          value={viewMode}
+          onChange={setViewMode}
+          members={members}
+        />
 
-          {isMember && selectedMember && (
-            <MemberProgressView
-              memberId={selectedMember.id}
-              memberName={selectedMember.name}
-              teamId={teamId}
-              seasonId={selectedSeasonId}
-              onBack={() => setViewMode('team')}
-            />
-          )}
-        </Box>
-      )}
+        {!selectedSeasonId ? (
+          <Box sx={{ py: 6, textAlign: 'center' }}>
+            <Typography color="text.secondary">
+              {i18next.t('progress.graph.selectSeason', 'Select a season to view progress.')}
+            </Typography>
+          </Box>
+        ) : (
+          <Box sx={{ mt: 2 }}>
+            {isPersonal && (
+              <PersonalProgressView
+                teamId={teamId}
+                seasonId={selectedSeasonId}
+                canParticipate={canParticipate}
+              />
+            )}
+
+            {isTeam && (
+              <TeamOverviewView
+                teamId={teamId}
+                seasonId={selectedSeasonId}
+                members={members}
+                onMemberSelect={(memberId) => setViewMode(memberId)}
+              />
+            )}
+
+            {isMember && !selectedMember && (
+              <Box sx={{ py: 6, textAlign: 'center' }}>
+                <Typography color="text.secondary">
+                  {i18next.t('progress.selectMember', 'Select a member from the list above to view their progress.')}
+                </Typography>
+              </Box>
+            )}
+
+            {isMember && selectedMember && (
+              <MemberProgressView
+                memberId={selectedMember.id}
+                memberName={selectedMember.name}
+                teamId={teamId}
+                seasonId={selectedSeasonId}
+                onBack={() => setViewMode('team')}
+              />
+            )}
+          </Box>
+        )}
+      </Paper>
     </Container>
   );
 }

--- a/src/resources/styles/index.scss
+++ b/src/resources/styles/index.scss
@@ -39,6 +39,7 @@ body {
   @include meta.load-css("pages/goals");
   @include meta.load-css("pages/goal-details");
   @include meta.load-css("pages/season-details");
+  @include meta.load-css("pages/progress");
   @include meta.load-css("pages/progress-details");
   @include meta.load-css("pages/progress-creation");
   @include meta.load-css("pages/dashboard");

--- a/src/resources/styles/pages/progress.scss
+++ b/src/resources/styles/pages/progress.scss
@@ -1,0 +1,56 @@
+@use '../variables' as *;
+@use '../mixins' as *;
+
+.progress-page {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.progress-chart-section {
+  background: var(--palette-background-paper);
+}
+
+.progress-reports-section {
+  background: var(--palette-background-paper);
+}
+
+.progress-reports-title {
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.progress-report-item {
+  padding: 12px;
+  border: 1px solid var(--palette-divider);
+  border-radius: 6px;
+  margin-bottom: 8px;
+  cursor: pointer;
+  color: var(--palette-text-primary);
+
+  &:hover {
+    background: var(--palette-action-hover);
+  }
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.progress-report-item-summary {
+  font-weight: 500;
+}
+
+.progress-report-item-date {
+  font-size: 0.75rem;
+  color: var(--palette-text-secondary);
+  margin-top: 2px;
+}
+
+.progress-activity-dot {
+  &:focus-visible {
+    outline: 2px solid var(--palette-primary-main);
+    outline-offset: 4px;
+    border-radius: 50%;
+  }
+}

--- a/src/utils/__tests__/chartUtils.test.ts
+++ b/src/utils/__tests__/chartUtils.test.ts
@@ -1,0 +1,62 @@
+import { buildGoalActivityScatterData } from '../chartUtils';
+
+const mockGoals = [
+  { id: 'goal-1', title: 'Serve accuracy' },
+  { id: 'goal-2', title: 'Jump height' },
+];
+
+const mockReports = [
+  {
+    id: 'report-1',
+    authorId: 'user-1',
+    reportDate: '2025-03-01T00:00:00Z',
+    summary: 'Good week',
+    progress: [
+      { id: 'entry-1', goalId: 'goal-1', rating: 4, details: 'Improved' },
+      { id: 'entry-2', goalId: 'goal-2', rating: 2, details: 'Struggling' },
+    ],
+  },
+];
+
+describe('buildGoalActivityScatterData', () => {
+  it('maps each progress entry to a scatter point', () => {
+    const { points, goalNames } = buildGoalActivityScatterData(mockReports as any, mockGoals as any);
+
+    expect(points).toHaveLength(2);
+    expect(goalNames).toEqual(['Serve accuracy', 'Jump height']);
+
+    expect(points[0]).toMatchObject({
+      x: new Date('2025-03-01T00:00:00Z').getTime(),
+      y: 0,
+      rating: 4,
+      progressId: 'entry-1',
+      reportId: 'report-1',
+      goalName: 'Serve accuracy',
+      isOnTrack: true,
+    });
+
+    expect(points[1]).toMatchObject({
+      y: 1,
+      rating: 2,
+      isOnTrack: false,
+    });
+  });
+
+  it('skips progress entries whose goalId is not in the goals list', () => {
+    const reportsWithUnknownGoal = [
+      {
+        id: 'report-2',
+        reportDate: '2025-03-05T00:00:00Z',
+        progress: [{ id: 'e-1', goalId: 'unknown-goal', rating: 3 }],
+      },
+    ];
+    const { points } = buildGoalActivityScatterData(reportsWithUnknownGoal as any, mockGoals as any);
+    expect(points).toHaveLength(0);
+  });
+
+  it('returns empty arrays when there are no reports', () => {
+    const { points, goalNames } = buildGoalActivityScatterData([], mockGoals as any);
+    expect(points).toHaveLength(0);
+    expect(goalNames).toEqual(['Serve accuracy', 'Jump height']);
+  });
+});

--- a/src/utils/__tests__/chartUtils.test.ts
+++ b/src/utils/__tests__/chartUtils.test.ts
@@ -9,7 +9,7 @@ const mockReports = [
   {
     id: 'report-1',
     authorId: 'user-1',
-    reportDate: '2025-03-01T00:00:00Z',
+    createdAt: '2025-03-01T00:00:00Z',
     summary: 'Good week',
     progress: [
       { id: 'entry-1', goalId: 'goal-1', rating: 4, details: 'Improved' },
@@ -20,7 +20,7 @@ const mockReports = [
 
 describe('buildGoalActivityScatterData', () => {
   it('maps each progress entry to a scatter point', () => {
-    const { points, goalNames } = buildGoalActivityScatterData(mockReports as any, mockGoals as any);
+    const { points, goalNames } = buildGoalActivityScatterData(mockReports, mockGoals);
 
     expect(points).toHaveLength(2);
     expect(goalNames).toEqual(['Serve accuracy', 'Jump height']);
@@ -46,17 +46,26 @@ describe('buildGoalActivityScatterData', () => {
     const reportsWithUnknownGoal = [
       {
         id: 'report-2',
-        reportDate: '2025-03-05T00:00:00Z',
+        createdAt: '2025-03-05T00:00:00Z',
         progress: [{ id: 'e-1', goalId: 'unknown-goal', rating: 3 }],
       },
     ];
-    const { points } = buildGoalActivityScatterData(reportsWithUnknownGoal as any, mockGoals as any);
+    const { points } = buildGoalActivityScatterData(reportsWithUnknownGoal, mockGoals);
     expect(points).toHaveLength(0);
   });
 
   it('returns empty arrays when there are no reports', () => {
-    const { points, goalNames } = buildGoalActivityScatterData([], mockGoals as any);
+    const { points, goalNames } = buildGoalActivityScatterData([], mockGoals);
     expect(points).toHaveLength(0);
     expect(goalNames).toEqual(['Serve accuracy', 'Jump height']);
+  });
+
+  it('treats a rating of exactly 3 as on track', () => {
+    const reports = [{
+      id: 'r-3', createdAt: '2025-04-01T00:00:00Z',
+      progress: [{ id: 'e-3', goalId: 'goal-1', rating: 3 }],
+    }];
+    const { points } = buildGoalActivityScatterData(reports, mockGoals);
+    expect(points[0].isOnTrack).toBe(true);
   });
 });

--- a/src/utils/chartUtils.ts
+++ b/src/utils/chartUtils.ts
@@ -77,7 +77,7 @@ export interface ScatterPoint {
 export function buildGoalActivityScatterData(
   reports: Array<{
     id: string;
-    reportDate: string;
+    createdAt: string;
     progress?: Array<{ id: string; goalId: string; rating: number; details?: string }>;
   }>,
   goals: Array<{ id: string; title: string }>,
@@ -87,7 +87,7 @@ export function buildGoalActivityScatterData(
   const points: ScatterPoint[] = [];
 
   for (const report of reports) {
-    const x = new Date(report.reportDate).getTime();
+    const x = new Date(report.createdAt).getTime();
     for (const entry of report.progress ?? []) {
       const y = goalIndexMap.get(entry.goalId);
       if (y === undefined) continue;

--- a/src/utils/chartUtils.ts
+++ b/src/utils/chartUtils.ts
@@ -63,3 +63,45 @@ export function buildProgressChartData(
 
   return { data, chartGoals };
 }
+
+export interface ScatterPoint {
+  x: number;         // report date as Unix timestamp (ms)
+  y: number;         // index into goalNames array
+  rating: number;    // 1–5
+  progressId: string;
+  reportId: string;
+  goalName: string;
+  isOnTrack: boolean; // rating >= 3
+}
+
+export function buildGoalActivityScatterData(
+  reports: Array<{
+    id: string;
+    reportDate: string;
+    progress?: Array<{ id: string; goalId: string; rating: number; details?: string }>;
+  }>,
+  goals: Array<{ id: string; title: string }>,
+): { points: ScatterPoint[]; goalNames: string[] } {
+  const goalIndexMap = new Map(goals.map((g, i) => [g.id, i]));
+  const goalNames = goals.map((g) => g.title);
+  const points: ScatterPoint[] = [];
+
+  for (const report of reports) {
+    const x = new Date(report.reportDate).getTime();
+    for (const entry of report.progress ?? []) {
+      const y = goalIndexMap.get(entry.goalId);
+      if (y === undefined) continue;
+      points.push({
+        x,
+        y,
+        rating: entry.rating,
+        progressId: entry.id,
+        reportId: report.id,
+        goalName: goalNames[y],
+        isOnTrack: entry.rating >= 3,
+      });
+    }
+  }
+
+  return { points, goalNames };
+}


### PR DESCRIPTION
## Summary

- Adds `useProgressReportPermissions` hook deriving `canParticipate` / `canOversee` flags from existing permissions store
- Replaces monolithic `Progress.tsx` with a thin orchestrator that routes between `PersonalProgressView`, `TeamOverviewView`, and `MemberProgressView` based on those flags
- New `GoalActivityChart` (Recharts ScatterChart), `EntryDrawer`, and `ContextSwitcher` components support the interactive experience

## Details

- Members with only `individual_goals:write` see their own scatter chart + report list; no team access
- Coaches/trainers with only `members:read` land directly on the Team Overview (member cards with report counts)
- Admins with both permissions get a `ContextSwitcher` (ToggleButtonGroup + Autocomplete) to switch between views
- Clicking a chart dot opens an `EntryDrawer` with entry detail and edit/navigate links
- Clicking a member card drills into `MemberProgressView` (read-only wrapper around `PersonalProgressView`)
- Dot colors use `var(--palette-primary-main)` / `var(--palette-warning-main)` — no hardcoded hex values

## Test Plan

- [ ] 190 existing tests pass (`npm test`)
- [ ] Log in as member → `/progress` shows personal scatter chart only, no switcher, "+ New Report" button visible
- [ ] Log in as trainer → `/progress` shows Team Overview directly with member cards
- [ ] Log in as admin → `/progress` shows ContextSwitcher, defaults to "My Progress"
- [ ] Click a chart dot → EntryDrawer opens; click "Edit" navigates; click "Open full report" navigates
- [ ] In Team Overview, click a member card → MemberProgressView shown with back button
- [ ] In ContextSwitcher, select "Team" → TeamOverviewView; select member from autocomplete → MemberProgressView